### PR TITLE
Reduce logging in tests by using slf4j-api instead of slf4j-simple, i…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,9 +241,8 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <version>1.7.36</version>
-      <scope>test</scope>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.16</version>
     </dependency>
   </dependencies>
   <build>
@@ -396,6 +395,8 @@
             <!-- readme -->
             <exclude>README.adoc</exclude>
             <exclude>README.md</exclude>
+            <!-- test logging config -->
+            <exclude>src/test/resources/log4j2-test.xml</exclude>
             <!-- dummy files -->
             <exclude>src/test/resources/hdfslist/**</exclude>
             <exclude>src/test/resources/csv/**</exclude>

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -9,7 +9,13 @@
     <Logger name="com.teragrep" level="info">
       <AppenderRef ref="Console"/>
     </Logger>
-    <Root level="warn">
+    <Logger name="org.apache.spark" level="warn">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Logger name="org.sparkproject.jetty" level="warn">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5p [%d] [%C] ({%t} %F[%M]:%L) - %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="com.teragrep" level="info">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Root level="warn">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
…ntroduce new log4j2-test.xml

Note: Currently prints warning about multiple slf4j providers, but only once.

```
[INFO] Running com.teragrep.pth10.ReplaceTransformationTest
SLF4J: Class path contains multiple SLF4J providers.
SLF4J: Found provider [org.apache.logging.slf4j.SLF4JServiceProvider@2dfaea86]
SLF4J: Found provider [org.slf4j.jul.JULServiceProvider@15888343]
SLF4J: See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual provider is of type [org.apache.logging.slf4j.SLF4JServiceProvider@2dfaea86]
```

Fixes #305 