### PR TITLE
Pattern acceleration support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <teragrep.jpr_01.version>3.1.1</teragrep.jpr_01.version>
     <teragrep.jue_01.version>0.4.3</teragrep.jue_01.version>
     <teragrep.pth_03.version>8.1.0</teragrep.pth_03.version>
-    <teragrep.pth_06.version>3.1.2</teragrep.pth_06.version>
+    <teragrep.pth_06.version>3.2.1</teragrep.pth_06.version>
     <teragrep.rlp_01.version>4.0.1</teragrep.rlp_01.version>
     <teragrep.rlp_03.version>1.7.6</teragrep.rlp_03.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <revision>0.0.1</revision>
     <sha1></sha1>
     <teragrep.dpf_02.version>3.0.0</teragrep.dpf_02.version>
-    <teragrep.dpf_03.version>10.0.1</teragrep.dpf_03.version>
+    <teragrep.dpf_03.version>11.0.1</teragrep.dpf_03.version>
     <teragrep.jpr_01.version>3.1.1</teragrep.jpr_01.version>
     <teragrep.jue_01.version>0.4.3</teragrep.jue_01.version>
     <teragrep.pth_03.version>8.1.0</teragrep.pth_03.version>

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/TeragrepTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/TeragrepTransformation.java
@@ -543,7 +543,7 @@ public class TeragrepTransformation extends DPLParserBaseVisitor<Node> {
             outputCol = new UnquotedText(new TextString(ctx.t_outputParameter().fieldType().getText())).read();
         }
 
-        return new StepNode(new TokenizerStep(tokenizerFormat, inputCol, outputCol));
+        return new StepNode(new TokenizerStep(zplnConfig, tokenizerFormat, inputCol, outputCol));
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTable.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTable.java
@@ -56,25 +56,25 @@ import java.sql.SQLException;
 public final class BloomFilterTable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BloomFilterTable.class);
-    private final CreateTableSQL table;
+    private final TableSQL tableSQL;
     private final LazyConnection conn;
 
     public BloomFilterTable(Config config) {
-        this(new CreateTableSQL(new FilterTypes(config).tableName(), false), new LazyConnection(config));
+        this(new TableSQL(new FilterTypes(config).tableName(), false), new LazyConnection(config));
     }
 
     // used in testing
     public BloomFilterTable(Config config, boolean ignoreConstraints) {
-        this(new CreateTableSQL(new FilterTypes(config).tableName(), ignoreConstraints), new LazyConnection(config));
+        this(new TableSQL(new FilterTypes(config).tableName(), ignoreConstraints), new LazyConnection(config));
     }
 
-    public BloomFilterTable(CreateTableSQL table, LazyConnection conn) {
-        this.table = table;
+    public BloomFilterTable(TableSQL tableSQL, LazyConnection conn) {
+        this.tableSQL = tableSQL;
         this.conn = conn;
     }
 
     public void create() {
-        final String sql = table.sql();
+        final String sql = tableSQL.createTableSQL();
         final Connection connection = conn.get();
         try (final PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.execute();
@@ -95,6 +95,6 @@ public final class BloomFilterTable {
         if (object.getClass() != this.getClass())
             return false;
         final BloomFilterTable cast = (BloomFilterTable) object;
-        return this.table.equals(cast.table) && this.conn.equals(cast.conn);
+        return this.tableSQL.equals(cast.tableSQL) && this.conn.equals(cast.conn);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTable.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTable.java
@@ -1,0 +1,136 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import com.typesafe.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+
+public final class BloomFilterTable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BloomFilterTable.class);
+    private final boolean ignoreConstraints;
+    private final FilterTypes filterTypes;
+    private final LazyConnection conn;
+
+    public BloomFilterTable(Config config) {
+        this(new FilterTypes(config), new LazyConnection(config), false);
+    }
+
+    // used in testing
+    public BloomFilterTable(Config config, boolean ignoreConstraints) {
+        this(new FilterTypes(config), new LazyConnection(config), ignoreConstraints);
+    }
+
+    public BloomFilterTable(FilterTypes filterTypes, LazyConnection conn, boolean ignoreConstraints) {
+        this.filterTypes = filterTypes;
+        this.conn = conn;
+        this.ignoreConstraints = ignoreConstraints;
+    }
+
+    public void create() {
+        if (ignoreConstraints && LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Ignore database constraints active this should be only used in testing");
+        }
+        final String name = filterTypes.tableName();
+        final String sql = createTableSQL(name);
+        final Connection connection = conn.get();
+        try (final PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.execute();
+            connection.commit();
+            LOGGER.info("Created a bloom filter table name <[{}]>", name);
+            LOGGER.debug("Create table SQL <{}>", sql);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException("Error creating bloom filter table: " + e);
+        }
+    }
+
+    private String createTableSQL(final String name) {
+        final Pattern pattern = Pattern.compile("^[A-Za-z0-9_]+$");
+        if (!pattern.matcher(name).find()) {
+            throw new RuntimeException("dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _");
+        }
+        if (name.length() > 100) {
+            throw new RuntimeException(
+                    "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters"
+            );
+        }
+
+        if (ignoreConstraints) {
+            return "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                    + "`id`            BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                    + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                    + "`filter` LONGBLOB NOT NULL);";
+        }
+        return "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                + "`id`            BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                + "`filter` LONGBLOB NOT NULL," + "CONSTRAINT `" + name
+                + "_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)" + "ON DELETE CASCADE,"
+                + "CONSTRAINT `" + name + "_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)"
+                + "ON DELETE CASCADE" + ");";
+
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final BloomFilterTable cast = (BloomFilterTable) object;
+        return this.filterTypes.equals(cast.filterTypes) && this.conn.equals(cast.conn)
+                && this.ignoreConstraints == cast.ignoreConstraints;
+    }
+}

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQL.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQL.java
@@ -1,0 +1,54 @@
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import java.util.regex.Pattern;
+
+public class CreateTableSQL {
+    private final String name;
+
+    private void nameIsValid() {
+        final Pattern pattern = Pattern.compile("^[A-Za-z0-9_]+$");
+        if (!pattern.matcher(name).find()) {
+            throw new RuntimeException("dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _");
+        }
+        if (name.length() > 100) {
+            throw new RuntimeException(
+                    "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters"
+            );
+        }
+    }
+    public CreateTableSQL(String name) {
+        this.name = name;
+    }
+
+    public String sql() {
+        nameIsValid();
+        return "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                + "`filter` LONGBLOB NOT NULL," + "CONSTRAINT `" + name
+                + "_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)" + "ON DELETE CASCADE,"
+                + "CONSTRAINT `" + name + "_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)"
+                + "ON DELETE CASCADE" + ");";
+
+    }
+
+    public String ignoreConstraintsSql() {
+        nameIsValid();
+        return "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                + "`filter` LONGBLOB NOT NULL);";
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final CreateTableSQL cast = (CreateTableSQL) object;
+        return this.name.equals(cast.name);
+    }
+}

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQL.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQL.java
@@ -1,11 +1,65 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.regex.Pattern;
 
 public class CreateTableSQL {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateTableSQL.class);
     private final String name;
+    private final boolean ignoreConstraints;
 
     private void nameIsValid() {
+        if (ignoreConstraints && LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Ignore database constraints active this should be only used in testing");
+        }
         final Pattern pattern = Pattern.compile("^[A-Za-z0-9_]+$");
         if (!pattern.matcher(name).find()) {
             throw new RuntimeException("dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _");
@@ -16,28 +70,35 @@ public class CreateTableSQL {
             );
         }
     }
+
     public CreateTableSQL(String name) {
+        this(name, false);
+    }
+
+    public CreateTableSQL(String name, boolean ignoreConstraints) {
         this.name = name;
+        this.ignoreConstraints = ignoreConstraints;
     }
 
     public String sql() {
         nameIsValid();
-        return "CREATE TABLE IF NOT EXISTS `" + name + "`("
-                + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
-                + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
-                + "`filter` LONGBLOB NOT NULL," + "CONSTRAINT `" + name
-                + "_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)" + "ON DELETE CASCADE,"
-                + "CONSTRAINT `" + name + "_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)"
-                + "ON DELETE CASCADE" + ");";
-
-    }
-
-    public String ignoreConstraintsSql() {
-        nameIsValid();
-        return "CREATE TABLE IF NOT EXISTS `" + name + "`("
-                + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
-                + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
-                + "`filter` LONGBLOB NOT NULL);";
+        final String sql;
+        if (ignoreConstraints) {
+            sql = "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                    + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                    + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                    + "`filter` LONGBLOB NOT NULL);";
+        }
+        else {
+            sql = "CREATE TABLE IF NOT EXISTS `" + name + "`("
+                    + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
+                    + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"
+                    + "`filter` LONGBLOB NOT NULL," + "CONSTRAINT `" + name
+                    + "_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)" + "ON DELETE CASCADE,"
+                    + "CONSTRAINT `" + name + "_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)"
+                    + "ON DELETE CASCADE" + ");";
+        }
+        return sql;
     }
 
     @Override
@@ -49,6 +110,6 @@ public class CreateTableSQL {
         if (object.getClass() != this.getClass())
             return false;
         final CreateTableSQL cast = (CreateTableSQL) object;
-        return this.name.equals(cast.name);
+        return this.name.equals(cast.name) && this.ignoreConstraints == cast.ignoreConstraints;
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
@@ -47,26 +47,22 @@ package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
 import com.typesafe.config.Config;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sparkproject.guava.reflect.TypeToken;
 
 import java.io.Serializable;
 import java.util.*;
 
-import static com.teragrep.pth10.steps.teragrep.TeragrepBloomStep.BLOOM_NUMBER_OF_FIELDS_CONFIG_ITEM;
+public final class FilterTypes implements Serializable {
 
-public class FilterSizes implements Serializable {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FilterSizes.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilterTypes.class);
 
     private final Config config;
-    private final ArrayList<SortedMap<Long, Double>> mapCache = new ArrayList<>(1);
-    private final ArrayList<Map<Long, Long>> bitSizeMapCache = new ArrayList<>(1);
 
-    public FilterSizes(Config config) {
+    public FilterTypes(Config config) {
         this.config = config;
     }
 
@@ -74,45 +70,20 @@ public class FilterSizes implements Serializable {
      * Filter sizes as sorted map
      * <p>
      * Keys = filter expected num of items, values = filter FPP
-     * 
+     *
      * @return SortedMap of filter configuration
      */
-    public SortedMap<Long, Double> asSortedMap() {
-        if (mapCache.isEmpty()) {
-            SortedMap<Long, Double> resultMap = mapFromConfig();
-            mapCache.add(resultMap);
-        }
-        return mapCache.get(0);
-    }
-
-    public Map<Long, Long> asBitsizeSortedMap() {
-        if (bitSizeMapCache.isEmpty()) {
-            Map<Long, Double> filterSizes = asSortedMap();
-            Map<Long, Long> bitsizeToExpectedItemsMap = new HashMap<>();
-            // Calculate bitSizes
-            for (Map.Entry<Long, Double> entry : filterSizes.entrySet()) {
-                BloomFilter bf = BloomFilter.create(entry.getKey(), entry.getValue());
-                bitsizeToExpectedItemsMap.put(bf.bitSize(), entry.getKey());
-            }
-            bitSizeMapCache.add(bitsizeToExpectedItemsMap);
-        }
-        return bitSizeMapCache.get(0);
-    }
-
-    private SortedMap<Long, Double> mapFromConfig() {
-
-        SortedMap<Long, Double> sizesMapFromJson = new TreeMap<>();
-        Gson gson = new Gson();
-
-        List<JsonObject> jsonArray = gson.fromJson(sizesJsonString(), new TypeToken<List<JsonObject>>() {
+    public SortedMap<Long, Double> sortedMap() {
+        final SortedMap<Long, Double> sizesMapFromJson = new TreeMap<>();
+        final Gson gson = new Gson();
+        final List<JsonObject> jsonArray = gson.fromJson(sizesJsonString(), new TypeToken<List<JsonObject>>() {
         }.getType());
-
-        for (JsonObject object : jsonArray) {
+        for (final JsonObject object : jsonArray) {
             if (object.has("expected") && object.has("fpp")) {
-                Long expectedNumOfItems = Long.parseLong(object.get("expected").toString());
-                Double fpp = Double.parseDouble(object.get("fpp").toString());
+                final Long expectedNumOfItems = Long.parseLong(object.get("expected").toString());
+                final Double fpp = Double.parseDouble(object.get("fpp").toString());
                 if (sizesMapFromJson.containsKey(expectedNumOfItems)) {
-                    LOGGER.error("Duplicate value of expected number of items value: <{}>", expectedNumOfItems);
+                    LOGGER.error("Duplicate value of expected number of items value: <[{}]>", expectedNumOfItems);
                     throw new RuntimeException("Duplicate entry expected num of items");
                 }
                 sizesMapFromJson.put(expectedNumOfItems, fpp);
@@ -124,17 +95,74 @@ public class FilterSizes implements Serializable {
         return sizesMapFromJson;
     }
 
+    public Map<Long, Long> bitSizeMap() {
+        final Map<Long, Double> filterSizes = sortedMap();
+        final Map<Long, Long> bitsizeToExpectedItemsMap = new HashMap<>();
+        // Calculate bitSizes
+        for (final Map.Entry<Long, Double> entry : filterSizes.entrySet()) {
+            final BloomFilter bf = BloomFilter.create(entry.getKey(), entry.getValue());
+            bitsizeToExpectedItemsMap.put(bf.bitSize(), entry.getKey());
+        }
+        return bitsizeToExpectedItemsMap;
+    }
+
+    public String pattern() {
+        final String pattern;
+        final String BLOOM_PATTERN_CONFIG_ITEM = "dpl.pth_06.bloom.pattern";
+        if (config.hasPath(BLOOM_PATTERN_CONFIG_ITEM)) {
+            final String patternFromConfig = config.getString(BLOOM_PATTERN_CONFIG_ITEM);
+            if (patternFromConfig == null || patternFromConfig.isEmpty()) {
+                throw new RuntimeException("Bloom filter pattern was not configured.");
+            }
+            pattern = patternFromConfig.trim();
+        }
+        else {
+            throw new RuntimeException("Missing configuration item: '" + BLOOM_PATTERN_CONFIG_ITEM + "'.");
+        }
+        return pattern;
+    }
+
+    public String tableName() {
+        final String tableName;
+        final String BLOOM_TABLE_NAME_ITEM = "dpl.pth_06.bloom.table.name";
+        if (config.hasPath(BLOOM_TABLE_NAME_ITEM)) {
+            final String tableNameFromConfig = config.getString(BLOOM_TABLE_NAME_ITEM);
+            if (tableNameFromConfig == null || tableNameFromConfig.isEmpty()) {
+                throw new RuntimeException("Bloom filter table name was not configured.");
+            }
+            tableName = tableNameFromConfig.replaceAll("\\s", "").trim();
+        }
+        else {
+            throw new RuntimeException("Missing configuration item: '" + BLOOM_TABLE_NAME_ITEM + "'.");
+        }
+
+        return tableName;
+    }
+
     private String sizesJsonString() {
-        String jsonString;
+        final String jsonString;
+        final String BLOOM_NUMBER_OF_FIELDS_CONFIG_ITEM = "dpl.pth_06.bloom.db.fields";
         if (config.hasPath(BLOOM_NUMBER_OF_FIELDS_CONFIG_ITEM)) {
             jsonString = config.getString(BLOOM_NUMBER_OF_FIELDS_CONFIG_ITEM);
             if (jsonString == null || jsonString.isEmpty()) {
-                throw new RuntimeException("Bloom filter fields not configured.");
+                throw new RuntimeException("Bloom filter size fields was not configured.");
             }
         }
         else {
             throw new RuntimeException("Missing configuration item: '" + BLOOM_NUMBER_OF_FIELDS_CONFIG_ITEM + "'.");
         }
         return jsonString;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final FilterTypes cast = (FilterTypes) object;
+        return config.equals(cast.config);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnection.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnection.java
@@ -52,11 +52,7 @@ import java.sql.SQLException;
 
 import com.typesafe.config.Config;
 
-import static com.teragrep.pth10.steps.teragrep.TeragrepBloomStep.BLOOMDB_URL_CONFIG_ITEM;
-import static com.teragrep.pth10.steps.teragrep.TeragrepBloomStep.BLOOMDB_USERNAME_CONFIG_ITEM;
-import static com.teragrep.pth10.steps.teragrep.TeragrepBloomStep.BLOOMDB_PASSWORD_CONFIG_ITEM;
-
-public class LazyConnection implements Serializable {
+public final class LazyConnection implements Serializable {
 
     private static Connection connection = null;
     private final Config config;
@@ -86,6 +82,7 @@ public class LazyConnection implements Serializable {
     private String connectionUsername() {
 
         String username;
+        String BLOOMDB_USERNAME_CONFIG_ITEM = "dpl.pth_10.bloom.db.username";
         if (config.hasPath(BLOOMDB_USERNAME_CONFIG_ITEM)) {
             username = config.getString(BLOOMDB_USERNAME_CONFIG_ITEM);
             if (username == null || username.isEmpty()) {
@@ -101,6 +98,7 @@ public class LazyConnection implements Serializable {
     private String connectionPassword() {
 
         String password;
+        String BLOOMDB_PASSWORD_CONFIG_ITEM = "dpl.pth_10.bloom.db.password";
         if (config.hasPath(BLOOMDB_PASSWORD_CONFIG_ITEM)) {
             password = config.getString(BLOOMDB_PASSWORD_CONFIG_ITEM);
             if (password == null) {
@@ -116,6 +114,7 @@ public class LazyConnection implements Serializable {
     private String connectionURL() {
 
         String databaseUrl;
+        String BLOOMDB_URL_CONFIG_ITEM = "dpl.pth_06.bloom.db.url";
         if (config.hasPath(BLOOMDB_URL_CONFIG_ITEM)) {
             databaseUrl = config.getString(BLOOMDB_URL_CONFIG_ITEM);
             if (databaseUrl == null || databaseUrl.isEmpty()) {
@@ -126,5 +125,20 @@ public class LazyConnection implements Serializable {
             throw new RuntimeException("Missing configuration item: '" + BLOOMDB_URL_CONFIG_ITEM + "'.");
         }
         return databaseUrl;
+    }
+
+    /**
+     * Connection parameter not considered in equals method because of lazy init
+     */
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final LazyConnection cast = (LazyConnection) object;
+        return this.config.equals(cast.config);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnection.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnection.java
@@ -64,9 +64,9 @@ public final class LazyConnection implements Serializable {
     public synchronized Connection get() {
         if (connection == null) {
             // lazy init
-            String connectionURL = connectionURL();
-            String username = connectionUsername();
-            String password = connectionPassword();
+            final String connectionURL = connectionURL();
+            final String username = connectionUsername();
+            final String password = connectionPassword();
 
             try {
                 connection = DriverManager.getConnection(connectionURL, username, password);
@@ -80,9 +80,8 @@ public final class LazyConnection implements Serializable {
     }
 
     private String connectionUsername() {
-
-        String username;
-        String BLOOMDB_USERNAME_CONFIG_ITEM = "dpl.pth_10.bloom.db.username";
+        final String username;
+        final String BLOOMDB_USERNAME_CONFIG_ITEM = "dpl.pth_10.bloom.db.username";
         if (config.hasPath(BLOOMDB_USERNAME_CONFIG_ITEM)) {
             username = config.getString(BLOOMDB_USERNAME_CONFIG_ITEM);
             if (username == null || username.isEmpty()) {
@@ -96,9 +95,8 @@ public final class LazyConnection implements Serializable {
     }
 
     private String connectionPassword() {
-
-        String password;
-        String BLOOMDB_PASSWORD_CONFIG_ITEM = "dpl.pth_10.bloom.db.password";
+        final String password;
+        final String BLOOMDB_PASSWORD_CONFIG_ITEM = "dpl.pth_10.bloom.db.password";
         if (config.hasPath(BLOOMDB_PASSWORD_CONFIG_ITEM)) {
             password = config.getString(BLOOMDB_PASSWORD_CONFIG_ITEM);
             if (password == null) {
@@ -112,9 +110,8 @@ public final class LazyConnection implements Serializable {
     }
 
     private String connectionURL() {
-
-        String databaseUrl;
-        String BLOOMDB_URL_CONFIG_ITEM = "dpl.pth_06.bloom.db.url";
+        final String databaseUrl;
+        final String BLOOMDB_URL_CONFIG_ITEM = "dpl.pth_06.bloom.db.url";
         if (config.hasPath(BLOOMDB_URL_CONFIG_ITEM)) {
             databaseUrl = config.getString(BLOOMDB_URL_CONFIG_ITEM);
             if (databaseUrl == null || databaseUrl.isEmpty()) {

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQL.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQL.java
@@ -50,9 +50,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.regex.Pattern;
 
-public class CreateTableSQL {
+public class TableSQL {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CreateTableSQL.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(TableSQL.class);
     private final String name;
     private final boolean ignoreConstraints;
 
@@ -71,16 +71,16 @@ public class CreateTableSQL {
         }
     }
 
-    public CreateTableSQL(String name) {
+    public TableSQL(String name) {
         this(name, false);
     }
 
-    public CreateTableSQL(String name, boolean ignoreConstraints) {
+    public TableSQL(String name, boolean ignoreConstraints) {
         this.name = name;
         this.ignoreConstraints = ignoreConstraints;
     }
 
-    public String sql() {
+    public String createTableSQL() {
         nameIsValid();
         final String sql;
         if (ignoreConstraints) {
@@ -109,7 +109,7 @@ public class CreateTableSQL {
             return false;
         if (object.getClass() != this.getClass())
             return false;
-        final CreateTableSQL cast = (CreateTableSQL) object;
+        final TableSQL cast = (TableSQL) object;
         return this.name.equals(cast.name) && this.ignoreConstraints == cast.ignoreConstraints;
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
@@ -54,6 +54,7 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Objects;
 
 import org.slf4j.Logger;
@@ -88,8 +89,9 @@ public final class TeragrepBloomFilter {
         final long bitSize = filter.bitSize();
         final long selectedExpectedNumOfItems;
         final Double selectedFpp;
-        if (filterTypes.bitSizeMap().containsKey(bitSize)) {
-            final long expectedItems = filterTypes.bitSizeMap().get(bitSize);
+        final Map<Long, Long> bitSizeMap = filterTypes.bitSizeMap();
+        if (bitSizeMap.containsKey(bitSize)) {
+            final long expectedItems = bitSizeMap.get(bitSize);
             selectedExpectedNumOfItems = expectedItems;
             selectedFpp = filterTypes.sortedMap().get(expectedItems);
         }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
@@ -54,117 +54,106 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Map;
-import java.util.SortedMap;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Class create a selected sized {@link BloomFilter} and run operations
- */
-public class TeragrepBloomFilter {
+public final class TeragrepBloomFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TeragrepBloomFilter.class);
 
     private final String partitionID;
-    private final byte[] bloomfilterBytes;
+    private final BloomFilter filter;
     private final Connection connection;
-    private final FilterSizes filterSizes;
-    private Long selectedExpectedNumOfItems;
-    private Double selectedFpp;
+    private final FilterTypes filterTypes;
 
-    public TeragrepBloomFilter(
-            String partition,
-            byte[] bloomfilterBytes,
-            Connection connection,
-            FilterSizes filterSizes
-    ) {
-        this.partitionID = partition;
-        this.bloomfilterBytes = bloomfilterBytes;
-        this.filterSizes = filterSizes;
-        this.connection = connection;
+    public TeragrepBloomFilter(String partition, byte[] bytes, Connection connection, FilterTypes filterTypes) {
+        this(partition, new ToBloomFilter(bytes), connection, filterTypes);
     }
 
-    private BloomFilter sizedFilter() {
-
-        SortedMap<Long, Double> filterSizesMap = filterSizes.asSortedMap();
-        Map<Long, Long> bitsizeToExpectedItemsMap = filterSizes.asBitsizeSortedMap();
-
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bloomfilterBytes)) {
-            BloomFilter bf = BloomFilter.readFrom(bais);
-
-            long bitSize = bf.bitSize();
-            if (bitsizeToExpectedItemsMap.containsKey(bitSize)) {
-                long expectedItems = bitsizeToExpectedItemsMap.get(bitSize);
-                double fpp = filterSizesMap.get(expectedItems);
-                this.selectedExpectedNumOfItems = expectedItems;
-                this.selectedFpp = fpp;
-                return bf;
-            }
-            else {
-                throw new IllegalArgumentException("no such filterSize <[" + bitSize + "]>");
-            }
-        }
-        catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public TeragrepBloomFilter(String partition, BloomFilter filter, Connection connection, FilterTypes filterTypes) {
+        this.partitionID = partition;
+        this.filter = filter;
+        this.filterTypes = filterTypes;
+        this.connection = connection;
     }
 
     /**
      * Write filter bytes to database
-     * 
-     * @param overwriteExisting Set if existing filter data will be overwritten
+     *
+     * @param overwrite Set if existing filter data will be overwritten
      */
-    public void saveFilter(Boolean overwriteExisting) {
-
-        final BloomFilter filter = sizedFilter();
-        final String sql = sqlString(overwriteExisting);
-
-        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+    public void saveFilter(final Boolean overwrite) {
+        final long bitSize = filter.bitSize();
+        final long selectedExpectedNumOfItems;
+        final Double selectedFpp;
+        if (filterTypes.bitSizeMap().containsKey(bitSize)) {
+            final long expectedItems = filterTypes.bitSizeMap().get(bitSize);
+            selectedExpectedNumOfItems = expectedItems;
+            selectedFpp = filterTypes.sortedMap().get(expectedItems);
+        }
+        else {
+            throw new IllegalArgumentException("no such filterSize <[" + bitSize + "]>");
+        }
+        final String sql = sqlString(overwrite);
+        final String pattern = filterTypes.pattern();
+        LOGGER.debug("Save filter SQL: <{}>", sql);
+        try (final PreparedStatement stmt = connection.prepareStatement(sql)) {
+            try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
                 LOGGER
-                        .info(
-                                "Saving filter[expected: <{}> , fpp: <{}>] to bloomdb.bloomfilter, overwrite existing data: <{}>",
-                                selectedExpectedNumOfItems, selectedFpp, overwriteExisting
+                        .debug(
+                                "Saving filter expected <[{}]>, fpp <[{}]>, pattern <[{}]>, overwrite existing data=<{}>",
+                                selectedExpectedNumOfItems, selectedFpp, pattern, overwrite
                         );
-
                 filter.writeTo(baos);
                 InputStream is = new ByteArrayInputStream(baos.toByteArray());
-
                 stmt.setInt(1, Integer.parseInt(partitionID)); // bloomfilter.partition_id
-                stmt.setInt(2, selectedExpectedNumOfItems.intValue()); // filtertype.expectedElements
+                stmt.setInt(2, (int) selectedExpectedNumOfItems); // filtertype.expectedElements
                 stmt.setDouble(3, selectedFpp); // filtertype.targetFpp
-                stmt.setBlob(4, is); // bloomfilter.filter
+                stmt.setString(4, pattern); // filtertype.pattern
+                stmt.setBlob(5, is); // bloomfilter.filter
                 stmt.executeUpdate();
                 stmt.clearParameters();
-
                 is.close();
                 connection.commit();
-
             }
             catch (IOException e) {
-                throw new RuntimeException("Error serializing data\n" + e);
+                throw new RuntimeException("Error serializing data: " + e);
             }
             catch (SQLException e) {
-                throw new RuntimeException("Error writing to database\n" + e);
+                throw new RuntimeException("Error writing to database: " + e);
             }
         }
         catch (SQLException e) {
-            throw new RuntimeException("Error generating a prepared statement\n" + e);
+            throw new RuntimeException("Error generating a prepared statement: " + e);
         }
     }
 
-    private static String sqlString(Boolean overwriteExisting) {
+    private String sqlString(final Boolean overwriteExisting) {
         final String sql;
+        final String name = filterTypes.tableName();
         if (overwriteExisting) {
-            sql = "REPLACE INTO `bloomfilter` (`partition_id`, `filter_type_id`, `filter`) "
-                    + "VALUES(?, (SELECT `id` FROM `filtertype` WHERE expectedElements=? AND targetFpp=?),?)";
+            sql = "REPLACE INTO `" + name + "` (`partition_id`, `filter_type_id`,`filter`) " + "VALUES(?,"
+                    + "(SELECT `id` FROM `filtertype` WHERE expectedElements=? AND targetFpp=? AND pattern=?)," + "?)";
         }
         else {
-            sql = "INSERT IGNORE INTO `bloomfilter` (`partition_id`, `filter_type_id`, `filter`) "
-                    + "VALUES(?, (SELECT `id` FROM `filtertype` WHERE expectedElements=? AND targetFpp=?),?)";
+            sql = "INSERT IGNORE INTO `" + name + "` (`partition_id`, `filter_type_id`,`filter`) " + "VALUES(?,"
+                    + "(SELECT `id` FROM `filtertype` WHERE expectedElements=? AND targetFpp=? AND pattern=?)," + "?)";
         }
         return sql;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final TeragrepBloomFilter cast = (TeragrepBloomFilter) object;
+        return Objects.equals(this.partitionID, cast.partitionID) && this.connection.equals(cast.connection)
+                && this.filter.equals(cast.filter) && this.filterTypes.equals(cast.filterTypes);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilter.java
@@ -1,0 +1,182 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import org.apache.spark.util.sketch.BloomFilter;
+import org.apache.spark.util.sketch.IncompatibleMergeException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * BloomFilter from byte[] used in a constructor of TeragrepBloomFilter
+ * 
+ * @see TeragrepBloomFilter
+ */
+public final class ToBloomFilter extends BloomFilter {
+
+    private final byte[] bytes;
+    private final List<BloomFilter> cache;
+
+    public ToBloomFilter(byte[] bytes) {
+        super();
+        this.bytes = bytes;
+        this.cache = new ArrayList<>();
+    }
+
+    private BloomFilter fromBytes() {
+        // cache used to keep just one instance of the BloomFilter impl
+        if (cache.isEmpty()) {
+            final BloomFilter filter;
+            try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
+                filter = BloomFilter.readFrom(bais);
+            }
+            catch (IOException e) {
+                throw new RuntimeException("Error reading bytes to filter: " + e.getMessage());
+            }
+            cache.add(filter);
+        }
+        return cache.get(0);
+    }
+
+    @Override
+    public double expectedFpp() {
+        return fromBytes().expectedFpp();
+    }
+
+    @Override
+    public long bitSize() {
+        return fromBytes().bitSize();
+    }
+
+    @Override
+    public boolean put(final Object item) {
+        return fromBytes().put(item);
+    }
+
+    @Override
+    public boolean putString(final String item) {
+        return fromBytes().putString(item);
+    }
+
+    @Override
+    public boolean putLong(final long item) {
+        return fromBytes().putLong(item);
+    }
+
+    @Override
+    public boolean putBinary(final byte[] item) {
+        return fromBytes().putBinary(item);
+    }
+
+    @Override
+    public boolean isCompatible(final BloomFilter other) {
+        if (other.getClass() == this.getClass()) {
+            final ToBloomFilter cast = (ToBloomFilter) other;
+            return fromBytes().isCompatible(cast.fromBytes());
+        }
+        return fromBytes().isCompatible(other);
+    }
+
+    @Override
+    public BloomFilter mergeInPlace(final BloomFilter other) throws IncompatibleMergeException {
+        if (other.getClass() == this.getClass()) {
+            final ToBloomFilter cast = (ToBloomFilter) other;
+            return fromBytes().mergeInPlace(cast.fromBytes());
+        }
+        return fromBytes().mergeInPlace(other);
+    }
+
+    @Override
+    public BloomFilter intersectInPlace(final BloomFilter other) throws IncompatibleMergeException {
+        if (other.getClass() == this.getClass()) {
+            final ToBloomFilter cast = (ToBloomFilter) other;
+            return fromBytes().intersectInPlace(cast.fromBytes());
+        }
+        return fromBytes().intersectInPlace(other);
+    }
+
+    @Override
+    public boolean mightContain(final Object item) {
+        return fromBytes().mightContain(item);
+    }
+
+    @Override
+    public boolean mightContainString(final String item) {
+        return fromBytes().mightContainString(item);
+    }
+
+    @Override
+    public boolean mightContainLong(final long item) {
+        return fromBytes().mightContainLong(item);
+    }
+
+    @Override
+    public boolean mightContainBinary(final byte[] item) {
+        return fromBytes().mightContainBinary(item);
+    }
+
+    @Override
+    public void writeTo(final OutputStream out) throws IOException {
+        fromBytes().writeTo(out);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final ToBloomFilter cast = (ToBloomFilter) object;
+        return Arrays.equals(this.bytes, cast.bytes);
+    }
+}

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/AbstractTokenizerStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/AbstractTokenizerStep.java
@@ -53,66 +53,10 @@ public abstract class AbstractTokenizerStep extends AbstractStep {
         STRING, BYTES
     }
 
-    protected String inputCol = "_raw";
-    protected String outputCol = "tokens";
-
-    protected TokenizerFormat tokenizerFormat = TokenizerFormat.STRING;
+    protected ConfiguredUDF fromConfig;
 
     public AbstractTokenizerStep() {
         super();
     }
 
-    /**
-     * Sets the field for the tokenizer to run on
-     * 
-     * @param inputCol field name, defaults to '_raw'
-     */
-    public void setInputCol(String inputCol) {
-        this.inputCol = inputCol;
-    }
-
-    /**
-     * Set Tokenizer output column
-     * 
-     * @param outputCol output column
-     */
-    public void setOutputCol(String outputCol) {
-        this.outputCol = outputCol;
-    }
-
-    /**
-     * Set whether to return byte array or string
-     * 
-     * @param tokenizerFormat format enum; string or bytes
-     */
-    public void setTokenizerFormat(TokenizerFormat tokenizerFormat) {
-        this.tokenizerFormat = tokenizerFormat;
-    }
-
-    /**
-     * Gets the field set for the tokenizer
-     * 
-     * @return field name used in the tokenizer, default '_raw'
-     */
-    public String getInputCol() {
-        return inputCol;
-    }
-
-    /**
-     * Get tokenizer output column
-     * 
-     * @return output column
-     */
-    public String getOutputCol() {
-        return outputCol;
-    }
-
-    /**
-     * Get Tokenizer return type; bytes or string
-     * 
-     * @return bytes or string enum
-     */
-    public TokenizerFormat getTokenizerFormat() {
-        return tokenizerFormat;
-    }
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
@@ -43,64 +43,50 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth10.steps.teragrep.bloomfilter;
+package com.teragrep.pth10.steps.tokenizer;
 
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import org.apache.spark.util.sketch.BloomFilter;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
 
-import java.util.Map;
-import java.util.Properties;
+public final class RegexTokenizerUDF implements TokenizerApplicable {
 
-class FilterSizesTest {
+    private final String BLOOM_PATTERN_CONFIG_ITEM = "dpl.pth_06.bloom.pattern";
+    private final Config config;
+    private final AbstractTokenizerStep.TokenizerFormat format;
+    private final String inputCol;
+    private final String outputCol;
 
-    @Test
-    public void filterSizeMapTest() {
-
-        Properties properties = new Properties();
-
-        properties
-                .put(
-                        "dpl.pth_06.bloom.db.fields",
-                        "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 2000, fpp: 0.01},"
-                                + "{expected: 3000, fpp: 0.01}" + "]"
-                );
-
-        Config config = ConfigFactory.parseProperties(properties);
-        FilterSizes sizeMap = new FilterSizes(config);
-
-        Map<Long, Double> resultMap = sizeMap.asSortedMap();
-
-        Assertions.assertEquals(0.01, resultMap.get(1000L));
-        Assertions.assertEquals(0.01, resultMap.get(2000L));
-        Assertions.assertEquals(0.01, resultMap.get(3000L));
-        Assertions.assertEquals(3, resultMap.size());
-
+    public RegexTokenizerUDF(
+            Config config,
+            AbstractTokenizerStep.TokenizerFormat format,
+            String inputCol,
+            String outputCol
+    ) {
+        this.config = config;
+        this.format = format;
+        this.inputCol = inputCol;
+        this.outputCol = outputCol;
     }
 
-    @Test
-    public void bitSizeMapTest() {
-
-        Properties properties = new Properties();
-
-        properties
-                .put(
-                        "dpl.pth_06.bloom.db.fields",
-                        "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 2000, fpp: 0.01},"
-                                + "{expected: 3000, fpp: 0.01}" + "]"
+    public Dataset<Row> appliedDataset(final Dataset<Row> dataset) {
+        final String pattern = config.getString(BLOOM_PATTERN_CONFIG_ITEM).trim();
+        final UserDefinedFunction regexUDF = functions
+                .udf(
+                        new com.teragrep.functions.dpf_03.RegexTokenizerUDF(),
+                        DataTypes.createArrayType(DataTypes.BinaryType, false)
                 );
 
-        Config config = ConfigFactory.parseProperties(properties);
-        FilterSizes sizeMap = new FilterSizes(config);
-
-        Map<Long, Long> bitSizeMap = sizeMap.asBitsizeSortedMap();
-
-        Assertions.assertEquals(1000L, bitSizeMap.get(BloomFilter.create(1000, 0.01).bitSize()));
-        Assertions.assertEquals(2000L, bitSizeMap.get(BloomFilter.create(2000, 0.01).bitSize()));
-        Assertions.assertEquals(3000L, bitSizeMap.get(BloomFilter.create(3000, 0.01).bitSize()));
-        Assertions.assertEquals(3, bitSizeMap.size());
-
+        if (this.format == AbstractTokenizerStep.TokenizerFormat.BYTES) {
+            return dataset.withColumn(outputCol, regexUDF.apply(functions.col(inputCol), functions.lit(pattern)));
+        }
+        else {
+            throw new UnsupportedOperationException(
+                    "TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option"
+            );
+        }
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
@@ -54,7 +54,6 @@ import org.apache.spark.sql.types.DataTypes;
 
 public final class RegexTokenizerUDF implements TokenizerApplicable {
 
-    private final String BLOOM_PATTERN_CONFIG_ITEM = "dpl.pth_06.bloom.pattern";
     private final Config config;
     private final AbstractTokenizerStep.TokenizerFormat format;
     private final String inputCol;
@@ -73,6 +72,7 @@ public final class RegexTokenizerUDF implements TokenizerApplicable {
     }
 
     public Dataset<Row> appliedDataset(final Dataset<Row> dataset) {
+        final String BLOOM_PATTERN_CONFIG_ITEM = "dpl.pth_06.bloom.pattern";
         final String pattern = config.getString(BLOOM_PATTERN_CONFIG_ITEM).trim();
         final UserDefinedFunction regexUDF = functions
                 .udf(
@@ -83,10 +83,6 @@ public final class RegexTokenizerUDF implements TokenizerApplicable {
         if (this.format == AbstractTokenizerStep.TokenizerFormat.BYTES) {
             return dataset.withColumn(outputCol, regexUDF.apply(functions.col(inputCol), functions.lit(pattern)));
         }
-        else {
-            throw new UnsupportedOperationException(
-                    "TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option"
-            );
-        }
+        throw new UnsupportedOperationException("TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option");
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/RegexTokenizerUDF.java
@@ -83,6 +83,8 @@ public final class RegexTokenizerUDF implements TokenizerApplicable {
         if (this.format == AbstractTokenizerStep.TokenizerFormat.BYTES) {
             return dataset.withColumn(outputCol, regexUDF.apply(functions.col(inputCol), functions.lit(pattern)));
         }
-        throw new UnsupportedOperationException("TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option");
+        throw new UnsupportedOperationException(
+                "TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option"
+        );
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerApplicable.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerApplicable.java
@@ -43,51 +43,12 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth10.steps.teragrep.bloomfilter;
+package com.teragrep.pth10.steps.tokenizer;
 
-import com.typesafe.config.Config;
-import org.apache.spark.api.java.function.ForeachPartitionFunction;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 
-import java.sql.Connection;
-import java.util.Iterator;
+public interface TokenizerApplicable {
 
-public final class BloomFilterForeachPartitionFunction implements ForeachPartitionFunction<Row> {
-
-    private final FilterTypes filterTypes;
-    private final LazyConnection lazyConnection;
-    private final boolean overwrite;
-
-    public BloomFilterForeachPartitionFunction(Config config) {
-        this(new FilterTypes(config), new LazyConnection(config), false);
-    }
-
-    public BloomFilterForeachPartitionFunction(Config config, boolean overwrite) {
-        this(new FilterTypes(config), new LazyConnection(config), overwrite);
-    }
-
-    public BloomFilterForeachPartitionFunction(
-            FilterTypes filterTypes,
-            LazyConnection lazyConnection,
-            boolean overwrite
-    ) {
-        this.filterTypes = filterTypes;
-        this.lazyConnection = lazyConnection;
-        this.overwrite = overwrite;
-    }
-
-    @Override
-    public void call(final Iterator<Row> iter) throws Exception {
-        final Connection conn = lazyConnection.get();
-        while (iter.hasNext()) {
-            final Row row = iter.next(); // Row[partitionID, filterBytes]
-            final String partition = row.getString(0);
-            final byte[] filterBytes = (byte[]) row.get(1);
-            final TeragrepBloomFilter tgFilter = new TeragrepBloomFilter(partition, filterBytes, conn, filterTypes);
-            tgFilter.saveFilter(overwrite);
-
-            conn.commit();
-
-        }
-    }
+    Dataset<Row> appliedDataset(Dataset<Row> dataset);
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerUDF.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerUDF.java
@@ -46,6 +46,7 @@
 package com.teragrep.pth10.steps.tokenizer;
 
 import com.teragrep.functions.dpf_03.ByteArrayListAsStringListUDF;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.expressions.UserDefinedFunction;
@@ -72,20 +73,19 @@ public final class TokenizerUDF implements TokenizerApplicable {
                         new com.teragrep.functions.dpf_03.TokenizerUDF(),
                         DataTypes.createArrayType(DataTypes.BinaryType, false)
                 );
-        final Dataset<Row> appliedDataset;
+        final Column appliedColumn;
         switch (format) {
             case BYTES:
-                appliedDataset = dataset.withColumn(outputCol, tokenizerUDF.apply(functions.col(inputCol)));
+                appliedColumn = tokenizerUDF.apply(functions.col(inputCol));
                 break;
             case STRING:
                 final UserDefinedFunction byteArrayListAsStringListUDF = functions
                         .udf(new ByteArrayListAsStringListUDF(), DataTypes.createArrayType(StringType));
-                appliedDataset = dataset
-                        .withColumn(outputCol, byteArrayListAsStringListUDF.apply(tokenizerUDF.apply(functions.col(inputCol))));
+                appliedColumn = byteArrayListAsStringListUDF.apply(tokenizerUDF.apply(functions.col(inputCol)));
                 break;
             default:
                 throw new IllegalStateException("Unexpected tokenizerFormat: " + format);
         }
-        return appliedDataset;
+        return dataset.withColumn(outputCol, appliedColumn);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerUDF.java
+++ b/src/main/java/com/teragrep/pth10/steps/tokenizer/TokenizerUDF.java
@@ -43,51 +43,45 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth10.steps.teragrep.bloomfilter;
+package com.teragrep.pth10.steps.tokenizer;
 
-import com.typesafe.config.Config;
-import org.apache.spark.api.java.function.ForeachPartitionFunction;
+import com.teragrep.functions.dpf_03.ByteArrayListAsStringListUDF;
+import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.expressions.UserDefinedFunction;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
 
-import java.sql.Connection;
-import java.util.Iterator;
+import static org.apache.spark.sql.types.DataTypes.StringType;
 
-public final class BloomFilterForeachPartitionFunction implements ForeachPartitionFunction<Row> {
+public final class TokenizerUDF implements TokenizerApplicable {
 
-    private final FilterTypes filterTypes;
-    private final LazyConnection lazyConnection;
-    private final boolean overwrite;
+    private final AbstractTokenizerStep.TokenizerFormat format;
+    private final String inputCol;
+    private final String outputCol;
 
-    public BloomFilterForeachPartitionFunction(Config config) {
-        this(new FilterTypes(config), new LazyConnection(config), false);
+    public TokenizerUDF(AbstractTokenizerStep.TokenizerFormat format, String inputCol, String outputCol) {
+        this.format = format;
+        this.inputCol = inputCol;
+        this.outputCol = outputCol;
     }
 
-    public BloomFilterForeachPartitionFunction(Config config, boolean overwrite) {
-        this(new FilterTypes(config), new LazyConnection(config), overwrite);
-    }
+    public Dataset<Row> appliedDataset(final Dataset<Row> dataset) {
+        final UserDefinedFunction tokenizerUDF = functions
+                .udf(
+                        new com.teragrep.functions.dpf_03.TokenizerUDF(),
+                        DataTypes.createArrayType(DataTypes.BinaryType, false)
+                );
 
-    public BloomFilterForeachPartitionFunction(
-            FilterTypes filterTypes,
-            LazyConnection lazyConnection,
-            boolean overwrite
-    ) {
-        this.filterTypes = filterTypes;
-        this.lazyConnection = lazyConnection;
-        this.overwrite = overwrite;
-    }
-
-    @Override
-    public void call(final Iterator<Row> iter) throws Exception {
-        final Connection conn = lazyConnection.get();
-        while (iter.hasNext()) {
-            final Row row = iter.next(); // Row[partitionID, filterBytes]
-            final String partition = row.getString(0);
-            final byte[] filterBytes = (byte[]) row.get(1);
-            final TeragrepBloomFilter tgFilter = new TeragrepBloomFilter(partition, filterBytes, conn, filterTypes);
-            tgFilter.saveFilter(overwrite);
-
-            conn.commit();
-
+        if (format == AbstractTokenizerStep.TokenizerFormat.BYTES) {
+            return dataset.withColumn(outputCol, tokenizerUDF.apply(functions.col(inputCol)));
         }
+        else if (format == AbstractTokenizerStep.TokenizerFormat.STRING) {
+            final UserDefinedFunction byteArrayListAsStringListUDF = functions
+                    .udf(new ByteArrayListAsStringListUDF(), DataTypes.createArrayType(StringType));
+            return dataset
+                    .withColumn(outputCol, byteArrayListAsStringListUDF.apply(tokenizerUDF.apply(functions.col(inputCol))));
+        }
+        throw new IllegalStateException("Unexpected tokenizerFormat: " + format);
     }
 }

--- a/src/test/java/com/teragrep/pth10/TokenizerTest.java
+++ b/src/test/java/com/teragrep/pth10/TokenizerTest.java
@@ -45,19 +45,33 @@
  */
 package com.teragrep.pth10;
 
+import com.teragrep.pth10.steps.tokenizer.AbstractTokenizerStep;
+import com.teragrep.pth10.steps.tokenizer.TokenizerStep;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TokenizerTest {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RexTransformationTest.class);
 
     private final String testFile = "src/test/resources/rexTransformationTest_data*.json"; // * to make the path into a directory path
     private final StructType testSchema = new StructType(new StructField[] {
@@ -137,5 +151,56 @@ public class TokenizerTest {
                             Assertions.assertEquals("bytetokens", ds.columns()[ds.columns().length - 1]);
                         }
                 );
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    public void testRegexTokenizerNotSupportedFormat() {
+        Properties properties = new Properties();
+        properties.put("dpl.pth_06.bloom.pattern", "testRegex");
+        Config config = ConfigFactory.parseProperties(properties);
+
+        TokenizerStep step = new TokenizerStep(config, AbstractTokenizerStep.TokenizerFormat.STRING, "_raw", "result");
+        SparkSession spark = streamingTestUtil.getCtx().getSparkSession();
+        UnsupportedOperationException exception = Assertions
+                .assertThrows(UnsupportedOperationException.class, () -> step.get(spark.read().schema(testSchema).csv(spark.emptyDataset(Encoders.STRING()))));
+        String e = "TokenizerFormat.STRING is not supported with regex tokenizer, remove bloom.pattern option";
+        Assertions.assertEquals(e, exception.getMessage());
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    public void testRegexTokenizerSelection() {
+        String regex = "^\\d+";
+        Pattern pattern = Pattern.compile(regex);
+        Properties properties = new Properties();
+        properties.put("dpl.pth_06.bloom.pattern", regex);
+        Config config = ConfigFactory.parseProperties(properties);
+
+        TokenizerStep step = new TokenizerStep(
+                config,
+                AbstractTokenizerStep.TokenizerFormat.BYTES,
+                "source",
+                "bytetokens"
+        );
+        SparkSession spark = streamingTestUtil.getCtx().getSparkSession();
+        Dataset<Row> result = step.get(spark.read().schema(testSchema).json(testFile));
+        // first row value: 127.0.0.0
+        List<Object> list = result.select("bytetokens").first().getList(0);
+        Set<String> tokens = new HashSet<>();
+        for (Object o : list) {
+            tokens.add(new String((byte[]) o, StandardCharsets.UTF_8));
+        }
+        Assertions.assertEquals(4, list.size());
+        Assertions.assertEquals(2, tokens.size());
+        Assertions.assertTrue(tokens.contains("127"));
+        Assertions.assertTrue(tokens.contains("0"));
+        Assertions.assertTrue(tokens.stream().allMatch(s -> pattern.matcher(s).matches()));
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
@@ -93,8 +93,7 @@ class BloomFilterTableTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, injectionTable::create);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _",
-                        e.getMessage()
+                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
                 );
     }
 

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
@@ -1,0 +1,197 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BloomFilterTableTest {
+
+    final String username = "sa";
+    final String password = "";
+    final String connectionUrl = "jdbc:h2:~/test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+
+    @BeforeAll
+    void setEnv() {
+        Config config = ConfigFactory.parseProperties(getDefaultProperties());
+        Connection connection = new LazyConnection(config).get();
+        Assertions.assertDoesNotThrow(() -> {
+            connection.prepareStatement("DROP ALL OBJECTS").execute(); // h2 clear database
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            Class.forName("org.h2.Driver");
+        });
+    }
+
+    @AfterAll
+    void tearDown() {
+        Assertions.assertDoesNotThrow(() -> {
+            Config config = ConfigFactory.parseProperties(getDefaultProperties());
+            Connection connection = new LazyConnection(config).get();
+            connection.prepareStatement("DROP ALL OBJECTS").execute(); // h2 clear database
+        });
+    }
+
+    @Test
+    void testInvalidInputCharacters() {
+        Properties properties = getDefaultProperties();
+        String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
+        properties.put("dpl.pth_06.bloom.table.name", injection);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable injectionTable = new BloomFilterTable(config, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, injectionTable::create);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _",
+                        e.getMessage()
+                );
+    }
+
+    @Test
+    void testInputOverMaxLimit() {
+        Properties properties = getDefaultProperties();
+        String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
+        properties.put("dpl.pth_06.bloom.table.name", tooLongName);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable table = new BloomFilterTable(config, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::create);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        e.getMessage()
+                );
+    }
+
+    @Test
+    void testCreateToDatabase() {
+        Properties properties = getDefaultProperties();
+        String tableName = "test_table";
+        properties.put("dpl.pth_06.bloom.table.name", tableName);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable table = new BloomFilterTable(config, true);
+        table.create();
+        String sql = "SHOW COLUMNS FROM " + tableName + ";";
+        Assertions.assertDoesNotThrow(() -> {
+            ResultSet rs = new LazyConnection(config).get().prepareStatement(sql).executeQuery();
+            int cols = 0;
+            List<String> columnList = new ArrayList<>(4);
+            while (rs.next()) {
+                columnList.add(rs.getString(1));
+                cols++;
+            }
+            Assertions.assertEquals(cols, 4);
+            Assertions.assertEquals(columnList.get(0), "id");
+            Assertions.assertEquals(columnList.get(1), "partition_id");
+            Assertions.assertEquals(columnList.get(2), "filter_type_id");
+            Assertions.assertEquals(columnList.get(3), "filter");
+            rs.close();
+        });
+    }
+
+    @Test
+    void testCreateToDatabaseFailure() {
+        Properties properties = getDefaultProperties();
+        String tableName = "test_table";
+        properties.put("dpl.pth_06.bloom.table.name", tableName);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable table = new BloomFilterTable(config);
+        Assertions.assertThrows(RuntimeException.class, table::create);
+    }
+
+    @Test
+    void testEquals() {
+        Properties properties = getDefaultProperties();
+        String tableName = "test_table";
+        properties.put("dpl.pth_06.bloom.table.name", tableName);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable table1 = new BloomFilterTable(config, true);
+        BloomFilterTable table2 = new BloomFilterTable(config, true);
+        table1.create();
+        Assertions.assertEquals(table1, table2);
+    }
+
+    @Test
+    void testNotEqualsName() {
+        Properties properties1 = getDefaultProperties();
+        Properties properties2 = getDefaultProperties();
+        properties1.put("dpl.pth_06.bloom.table.name", "test_table");
+        properties2.put("dpl.pth_06.bloom.table.name", "table_test");
+        Config config1 = ConfigFactory.parseProperties(properties1);
+        Config config2 = ConfigFactory.parseProperties(properties2);
+        BloomFilterTable table1 = new BloomFilterTable(config1, true);
+        BloomFilterTable table2 = new BloomFilterTable(config2, true);
+        table1.create();
+        Assertions.assertNotEquals(table1, table2);
+    }
+
+    @Test
+    void testNotEqualsIgnoreConstraints() {
+        Properties properties = getDefaultProperties();
+        String tableName = "test_table";
+        properties.put("dpl.pth_06.bloom.table.name", tableName);
+        Config config = ConfigFactory.parseProperties(properties);
+        BloomFilterTable table1 = new BloomFilterTable(config, true);
+        BloomFilterTable table2 = new BloomFilterTable(config, false);
+        table1.create();
+        Assertions.assertNotEquals(table1, table2);
+    }
+
+    private Properties getDefaultProperties() {
+        final Properties properties = new Properties();
+        properties.put("dpl.pth_10.bloom.db.username", username);
+        properties.put("dpl.pth_10.bloom.db.password", password);
+        properties.put("dpl.pth_06.bloom.db.url", connectionUrl);
+        return properties;
+    }
+}

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQLTest.java
@@ -1,0 +1,88 @@
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+class CreateTableSQLTest {
+
+    @Test
+    public void testSql() {
+        String name = "test_table";
+        CreateTableSQL table = new CreateTableSQL(name);
+        String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL,CONSTRAINT `test_table_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)ON DELETE CASCADE,CONSTRAINT `test_table_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)ON DELETE CASCADE);";
+        Assertions.assertEquals(e, table.sql());
+    }
+
+    @Test
+    public void testIgnoreConstraintsSql() {
+        String name = "test_table";
+        CreateTableSQL table = new CreateTableSQL(name);
+        String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";
+        Assertions.assertEquals(e, table.ignoreConstraintsSql());
+    }
+
+    @Test
+    public void testInvalidInputCharacters() {
+        String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
+        CreateTableSQL table = new CreateTableSQL(injection);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
+                );
+    }
+
+    @Test
+    public void testInvalidInputCharactersIgnoreConstraintsSql() {
+        String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
+        CreateTableSQL table = new CreateTableSQL(injection);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::ignoreConstraintsSql);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
+                );
+    }
+
+    @Test
+    public void testInputOverMaxLimit() {
+        String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
+        CreateTableSQL table = new CreateTableSQL(tooLongName);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        e.getMessage()
+                );
+    }
+
+    @Test
+    public void testInputOverMaxLimitIgnoreConstraintsSql() {
+        String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
+        CreateTableSQL table = new CreateTableSQL(tooLongName);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::ignoreConstraintsSql);
+        Assertions
+                .assertEquals(
+                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        e.getMessage()
+                );
+    }
+
+    @Test
+    public void testEquality() {
+        String name = "test_table";
+        CreateTableSQL table1 = new CreateTableSQL(name);
+        CreateTableSQL table2 = new CreateTableSQL(name);
+        Assertions.assertEquals(table1, table2);
+    }
+
+    @Test
+    public void testNotEqualNames() {
+        CreateTableSQL table1 = new CreateTableSQL("table_1");
+        CreateTableSQL table2 = new CreateTableSQL("table_2");
+        Assertions.assertNotEquals(table1, table2);
+    }
+}

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/CreateTableSQLTest.java
@@ -1,11 +1,52 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Properties;
 
 class CreateTableSQLTest {
 
@@ -20,9 +61,9 @@ class CreateTableSQLTest {
     @Test
     public void testIgnoreConstraintsSql() {
         String name = "test_table";
-        CreateTableSQL table = new CreateTableSQL(name);
+        CreateTableSQL table = new CreateTableSQL(name, true);
         String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";
-        Assertions.assertEquals(e, table.ignoreConstraintsSql());
+        Assertions.assertEquals(e, table.sql());
     }
 
     @Test
@@ -39,8 +80,8 @@ class CreateTableSQLTest {
     @Test
     public void testInvalidInputCharactersIgnoreConstraintsSql() {
         String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
-        CreateTableSQL table = new CreateTableSQL(injection);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::ignoreConstraintsSql);
+        CreateTableSQL table = new CreateTableSQL(injection, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
@@ -62,8 +103,8 @@ class CreateTableSQLTest {
     @Test
     public void testInputOverMaxLimitIgnoreConstraintsSql() {
         String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
-        CreateTableSQL table = new CreateTableSQL(tooLongName);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::ignoreConstraintsSql);
+        CreateTableSQL table = new CreateTableSQL(tooLongName, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
@@ -82,6 +123,13 @@ class CreateTableSQLTest {
     @Test
     public void testNotEqualNames() {
         CreateTableSQL table1 = new CreateTableSQL("table_1");
+        CreateTableSQL table2 = new CreateTableSQL("table_2");
+        Assertions.assertNotEquals(table1, table2);
+    }
+
+    @Test
+    public void testNotEqualIgnoreConstraints() {
+        CreateTableSQL table1 = new CreateTableSQL("table_1", true);
         CreateTableSQL table2 = new CreateTableSQL("table_2");
         Assertions.assertNotEquals(table1, table2);
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -1,0 +1,153 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.apache.spark.util.sketch.BloomFilter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FilterTypesTest {
+
+    @Test
+    public void testSortedMapMethod() {
+        Properties properties = new Properties();
+        properties
+                .put(
+                        "dpl.pth_06.bloom.db.fields",
+                        "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 2000, fpp: 0.01},"
+                                + "{expected: 3000, fpp: 0.01}" + "]"
+                );
+        Config config = ConfigFactory.parseProperties(properties);
+        FilterTypes filterTypes = new FilterTypes(config);
+        Map<Long, Double> resultMap = filterTypes.sortedMap();
+        assertEquals(0.01, resultMap.get(1000L));
+        assertEquals(0.01, resultMap.get(2000L));
+        assertEquals(0.01, resultMap.get(3000L));
+        assertEquals(3, resultMap.size());
+
+    }
+
+    @Test
+    public void testBitSizeMapMethod() {
+        Properties properties = new Properties();
+        properties
+                .put(
+                        "dpl.pth_06.bloom.db.fields",
+                        "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 2000, fpp: 0.01},"
+                                + "{expected: 3000, fpp: 0.01}" + "]"
+                );
+
+        Config config = ConfigFactory.parseProperties(properties);
+        FilterTypes filterTypes = new FilterTypes(config);
+        Map<Long, Long> bitSizeMap = filterTypes.bitSizeMap();
+        Assertions.assertEquals(1000L, bitSizeMap.get(BloomFilter.create(1000, 0.01).bitSize()));
+        Assertions.assertEquals(2000L, bitSizeMap.get(BloomFilter.create(2000, 0.01).bitSize()));
+        Assertions.assertEquals(3000L, bitSizeMap.get(BloomFilter.create(3000, 0.01).bitSize()));
+        Assertions.assertEquals(3, bitSizeMap.size());
+
+    }
+
+    @Test
+    public void testPatternMethod() {
+        String pattern = "test Regex ";
+        Properties properties = new Properties();
+        properties.put("dpl.pth_06.bloom.pattern", pattern);
+        Config config = ConfigFactory.parseProperties(properties);
+        FilterTypes filterTypes = new FilterTypes(config);
+        assertEquals("test Regex", filterTypes.pattern());
+    }
+
+    @Test
+    public void testTableTableNameMethod() {
+        String name = "test Table ";
+        Properties properties = new Properties();
+        properties.put("dpl.pth_06.bloom.table.name", name);
+        Config config = ConfigFactory.parseProperties(properties);
+        FilterTypes filterTypes = new FilterTypes(config);
+        assertEquals("testTable", filterTypes.tableName());
+    }
+
+    @Test
+    public void testEquals() {
+        Properties properties = new Properties();
+        properties.put("dpl.pth_06.bloom.table.name", "test");
+        properties.put("dpl.pth_06.bloom.pattern", "pattern");
+        properties
+                .put(
+                        "dpl.pth_06.bloom.db.fields",
+                        "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 2000, fpp: 0.01},"
+                                + "{expected: 3000, fpp: 0.01}" + "]"
+                );
+        Config config = ConfigFactory.parseProperties(properties);
+        FilterTypes filterTypes1 = new FilterTypes(config);
+        FilterTypes filterTypes2 = new FilterTypes(config);
+        filterTypes1.sortedMap();
+        filterTypes1.pattern();
+        filterTypes1.tableName();
+        filterTypes1.bitSizeMap();
+        assertEquals(filterTypes1, filterTypes2);
+    }
+
+    @Test
+    public void testNotEquals() {
+        Properties properties1 = new Properties();
+        properties1.put("dpl.pth_06.bloom.table.name", "test");
+        Properties properties2 = new Properties();
+        properties2.put("dpl.pth_06.bloom.table.name", "not_test");
+        Config config1 = ConfigFactory.parseProperties(properties1);
+        Config config2 = ConfigFactory.parseProperties(properties2);
+        FilterTypes filterTypes1 = new FilterTypes(config1);
+        FilterTypes filterTypes2 = new FilterTypes(config2);
+        assertNotEquals(filterTypes1, filterTypes2);
+    }
+}

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
@@ -48,29 +48,29 @@ package com.teragrep.pth10.steps.teragrep.bloomfilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-class CreateTableSQLTest {
+class TableSQLTest {
 
     @Test
-    public void testSql() {
+    public void testCreateTableSQL() {
         String name = "test_table";
-        CreateTableSQL table = new CreateTableSQL(name);
+        TableSQL table = new TableSQL(name);
         String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL,CONSTRAINT `test_table_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)ON DELETE CASCADE,CONSTRAINT `test_table_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)ON DELETE CASCADE);";
-        Assertions.assertEquals(e, table.sql());
+        Assertions.assertEquals(e, table.createTableSQL());
     }
 
     @Test
-    public void testIgnoreConstraintsSql() {
+    public void testIgnoreConstraintsCreateTableSQL() {
         String name = "test_table";
-        CreateTableSQL table = new CreateTableSQL(name, true);
+        TableSQL table = new TableSQL(name, true);
         String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";
-        Assertions.assertEquals(e, table.sql());
+        Assertions.assertEquals(e, table.createTableSQL());
     }
 
     @Test
     public void testInvalidInputCharacters() {
         String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
-        CreateTableSQL table = new CreateTableSQL(injection);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        TableSQL table = new TableSQL(injection);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
@@ -78,10 +78,10 @@ class CreateTableSQLTest {
     }
 
     @Test
-    public void testInvalidInputCharactersIgnoreConstraintsSql() {
+    public void testInvalidInputCharactersIgnoreConstraintsCreateTableSQL() {
         String injection = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
-        CreateTableSQL table = new CreateTableSQL(injection, true);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        TableSQL table = new TableSQL(injection, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
@@ -91,8 +91,8 @@ class CreateTableSQLTest {
     @Test
     public void testInputOverMaxLimit() {
         String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
-        CreateTableSQL table = new CreateTableSQL(tooLongName);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        TableSQL table = new TableSQL(tooLongName);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
@@ -101,10 +101,10 @@ class CreateTableSQLTest {
     }
 
     @Test
-    public void testInputOverMaxLimitIgnoreConstraintsSql() {
+    public void testInputOverMaxLimitIgnoreConstraintsCreateTableSQL() {
         String tooLongName = "testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati";
-        CreateTableSQL table = new CreateTableSQL(tooLongName, true);
-        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::sql);
+        TableSQL table = new TableSQL(tooLongName, true);
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
                         "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
@@ -115,22 +115,22 @@ class CreateTableSQLTest {
     @Test
     public void testEquality() {
         String name = "test_table";
-        CreateTableSQL table1 = new CreateTableSQL(name);
-        CreateTableSQL table2 = new CreateTableSQL(name);
+        TableSQL table1 = new TableSQL(name);
+        TableSQL table2 = new TableSQL(name);
         Assertions.assertEquals(table1, table2);
     }
 
     @Test
     public void testNotEqualNames() {
-        CreateTableSQL table1 = new CreateTableSQL("table_1");
-        CreateTableSQL table2 = new CreateTableSQL("table_2");
+        TableSQL table1 = new TableSQL("table_1");
+        TableSQL table2 = new TableSQL("table_2");
         Assertions.assertNotEquals(table1, table2);
     }
 
     @Test
     public void testNotEqualIgnoreConstraints() {
-        CreateTableSQL table1 = new CreateTableSQL("table_1", true);
-        CreateTableSQL table2 = new CreateTableSQL("table_2");
+        TableSQL table1 = new TableSQL("table_1", true);
+        TableSQL table2 = new TableSQL("table_2");
         Assertions.assertNotEquals(table1, table2);
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -54,31 +54,29 @@ import org.junit.jupiter.api.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class TeragrepBloomFilterTest {
 
-    private final String username = "sa";
-    private final String password = "";
-    private final String connectionUrl = "jdbc:h2:~/test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+    private final String pattern = "[a-zA-Z]*$";
     private LazyConnection lazyConnection;
-    private FilterSizes filterSizes;
+    private FilterTypes filterTypes;
     private final BloomFilter emptyFilter = BloomFilter.create(100, 0.01);
-
     private SortedMap<Long, Double> sizeMap;
+    private final String tableName = "bloomfilter_test";
 
     @BeforeAll
-    void setEnv() throws ClassNotFoundException, SQLException {
-
+    void setEnv() {
         Properties properties = new Properties();
+        String username = "sa";
         properties.put("dpl.pth_10.bloom.db.username", username);
+        String password = "";
         properties.put("dpl.pth_10.bloom.db.password", password);
+        String connectionUrl = "jdbc:h2:~/test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
         properties.put("dpl.pth_06.bloom.db.url", connectionUrl);
         properties
                 .put(
@@ -86,220 +84,260 @@ class TeragrepBloomFilterTest {
                         "[" + "{expected: 10000, fpp: 0.01}," + "{expected: 20000, fpp: 0.03},"
                                 + "{expected: 30000, fpp: 0.05}" + "]"
                 );
-
+        properties.put("dpl.pth_06.bloom.pattern", pattern);
+        properties.put("dpl.pth_06.bloom.table.name", tableName);
         Config config = ConfigFactory.parseProperties(properties);
         lazyConnection = new LazyConnection(config);
         Connection conn = lazyConnection.get();
-
-        conn.prepareStatement("DROP ALL OBJECTS").execute(); //h2 clear database
-
-        filterSizes = new FilterSizes(config);
-        sizeMap = filterSizes.asSortedMap();
-
-        Class.forName("org.h2.Driver");
-        sizeMap.put(10000L, 0.01);
-        sizeMap.put(20000L, 0.03);
-        sizeMap.put(30000L, 0.05);
-
+        Assertions.assertDoesNotThrow(() -> {
+            conn.prepareStatement("DROP ALL OBJECTS").execute(); // h2 clear database
+        });
+        Assertions.assertDoesNotThrow(() -> {
+            Class.forName("org.h2.Driver");
+        });
+        filterTypes = new FilterTypes(config);
+        sizeMap = filterTypes.sortedMap();
         String createFilterType = "CREATE TABLE `filtertype` ("
                 + "`id`               bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,"
-                + "`expectedElements` bigint(20) NOT NULL," + "`targetFpp`        DOUBLE UNSIGNED NOT NULL" + ");";
-
-        String createBloomFilter = "CREATE TABLE `bloomfilter` ("
+                + "`expectedElements` bigint(20) NOT NULL," + "`targetFpp`        DOUBLE UNSIGNED NOT NULL,"
+                + "`pattern`          VARCHAR(255) NOT NULL)";
+        String insertSql = "INSERT INTO `filtertype` " + "(`expectedElements`, `targetFpp`, `pattern`)"
+                + " VALUES (?, ?, ?)";
+        String createTable = "CREATE TABLE `" + tableName + "` ("
                 + "    `id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,"
                 + "    `partition_id` BIGINT(20) UNSIGNED NOT NULL,"
                 + "    `filter_type_id` BIGINT(20) UNSIGNED NOT NULL," + "    `filter` LONGBLOB NOT NULL" + ");";
-
-        String insertSql = "INSERT INTO `filtertype` (`expectedElements`, `targetFpp`) VALUES (?, ?)";
-
-        conn.prepareStatement(createFilterType).execute();
-        conn.prepareStatement(createBloomFilter).execute();
-
+        Assertions.assertDoesNotThrow(() -> {
+            conn.prepareStatement(createFilterType).execute();
+            conn.prepareStatement(createTable).execute();
+        });
+        int loops = 0;
         for (Map.Entry<Long, Double> entry : sizeMap.entrySet()) {
-            try (PreparedStatement stmt = conn.prepareStatement(insertSql)) {
-
+            loops++;
+            Assertions.assertDoesNotThrow(() -> {
+                PreparedStatement stmt = conn.prepareStatement(insertSql);
                 stmt.setInt(1, entry.getKey().intValue()); // filtertype.expectedElements
                 stmt.setDouble(2, entry.getValue()); // filtertype.targetFpp
+                stmt.setString(3, pattern);
                 stmt.executeUpdate();
                 stmt.clearParameters();
                 conn.commit();
-            }
+            });
         }
-
-        //ResultSet rs = conn.prepareStatement("SELECT * FROM `filtertype`;").executeQuery();
+        Assertions.assertEquals(3, loops);
     }
 
-    @AfterEach
-    void afterEach() throws SQLException {
-        lazyConnection.get().prepareStatement("TRUNCATE TABLE `bloomfilter`").execute();
+    @AfterAll
+    public void tearDown() {
+        Connection conn = lazyConnection.get();
+        Assertions.assertDoesNotThrow(() -> {
+            conn.prepareStatement("DROP ALL OBJECTS").execute(); // h2 clear database
+        });
     }
 
     // -- Tests --
 
     @Test
-    void filterSaveNoOverwriteTest() {
-
+    void testSavingToDatabase() {
         List<String> tokens = new ArrayList<>(Collections.singletonList("one"));
-        Row row = Assertions.assertDoesNotThrow(() -> generatedRow(sizeMap, tokens));
+        Row row = generatedRow(sizeMap, tokens);
         String partition = row.getString(0);
         byte[] filterBytes = (byte[]) row.get(1);
-        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, filterBytes, lazyConnection.get(), filterSizes);
+        BloomFilter rawFilter = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream(filterBytes)));
+        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, rawFilter, lazyConnection.get(), filterTypes);
         filter.saveFilter(false);
-
         Map.Entry<Long, Double> entry = sizeMap.entrySet().iterator().next();
-        String sql = "SELECT `filter` FROM `bloomfilter`;";
-
-        ResultSet rs = Assertions.assertDoesNotThrow(() -> lazyConnection.get().prepareStatement(sql).executeQuery());
-
-        int cols = Assertions.assertDoesNotThrow(() -> rs.getMetaData().getColumnCount());
-        BloomFilter resultFilter = emptyFilter;
-
-        while (Assertions.assertDoesNotThrow(() -> rs.next())) {
-            byte[] bytes = Assertions.assertDoesNotThrow(() -> rs.getBytes(1));
-            ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            resultFilter = Assertions.assertDoesNotThrow(() -> BloomFilter.readFrom(bais));
-        }
-
-        Assertions.assertNotNull(resultFilter);
-        Assertions.assertEquals(1, cols);
-        Assertions.assertTrue(resultFilter.mightContain("one"));
-        Assertions.assertFalse(resultFilter.mightContain("neo"));
-        Assertions.assertTrue(resultFilter.expectedFpp() <= entry.getValue());
-
-        Assertions.assertDoesNotThrow(rs::close);
+        String sql = "SELECT `filter` FROM `" + tableName + "`";
+        Assertions.assertDoesNotThrow(() -> {
+            ResultSet rs = lazyConnection.get().prepareStatement(sql).executeQuery();
+            int cols = rs.getMetaData().getColumnCount();
+            BloomFilter resultFilter = emptyFilter;
+            while (rs.next()) {
+                byte[] bytes = rs.getBytes(1);
+                ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                resultFilter = BloomFilter.readFrom(bais);
+            }
+            Assertions.assertNotNull(resultFilter);
+            Assertions.assertEquals(1, cols);
+            Assertions.assertTrue(resultFilter.mightContain("one"));
+            Assertions.assertFalse(resultFilter.mightContain("neo"));
+            Assertions.assertTrue(resultFilter.expectedFpp() <= entry.getValue());
+            rs.close();
+        });
     }
 
     @Test
-    void filterSaveOverwriteTest() {
-
+    void testSavingToDatabaseWithOverwrite() {
         List<String> tokens = new ArrayList<>(Collections.singletonList("one"));
-        Row row = Assertions.assertDoesNotThrow(() -> generatedRow(sizeMap, tokens));
+        Row row = generatedRow(sizeMap, tokens);
         String partition = row.getString(0);
         byte[] filterBytes = (byte[]) row.get(1);
-        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, filterBytes, lazyConnection.get(), filterSizes);
+        BloomFilter rawFilter = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream(filterBytes)));
+        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, rawFilter, lazyConnection.get(), filterTypes);
         filter.saveFilter(true);
-
-        String sql = "SELECT `filter` FROM `bloomfilter`;";
-
-        ResultSet rs = Assertions.assertDoesNotThrow(() -> lazyConnection.get().prepareStatement(sql).executeQuery());
-
-        int cols = Assertions.assertDoesNotThrow(() -> rs.getMetaData().getColumnCount());
-        BloomFilter resultFilter = emptyFilter;
-
-        while (Assertions.assertDoesNotThrow(() -> rs.next())) {
-            byte[] bytes = Assertions.assertDoesNotThrow(() -> rs.getBytes(1));
-            ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            resultFilter = Assertions.assertDoesNotThrow(() -> BloomFilter.readFrom(bais));
-        }
-
-        Assertions.assertNotNull(resultFilter);
-        Assertions.assertEquals(1, cols);
-        Assertions.assertTrue(resultFilter.mightContain("one"));
-        Assertions.assertFalse(resultFilter.mightContain("neo"));
-        Assertions.assertTrue(resultFilter.expectedFpp() <= 0.01D);
-        Assertions.assertDoesNotThrow(rs::close);
-
+        String sql = "SELECT `filter` FROM `" + tableName + "`";
+        Assertions.assertDoesNotThrow(() -> {
+            BloomFilter resultFilter = emptyFilter;
+            ResultSet rs = lazyConnection.get().prepareStatement(sql).executeQuery();
+            while (rs.next()) {
+                byte[] bytes = rs.getBytes(1);
+                ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                resultFilter = BloomFilter.readFrom(bais);
+            }
+            int cols = rs.getMetaData().getColumnCount();
+            Assertions.assertNotNull(resultFilter);
+            Assertions.assertEquals(1, cols);
+            Assertions.assertTrue(resultFilter.mightContain("one"));
+            Assertions.assertFalse(resultFilter.mightContain("neo"));
+            Assertions.assertTrue(resultFilter.expectedFpp() <= 0.01D);
+            Assertions.assertDoesNotThrow(rs::close);
+        });
         // Create second filter that will overwrite first one
-
         List<String> secondTokens = new ArrayList<>(Collections.singletonList("neo"));
-        Row secondRow = Assertions.assertDoesNotThrow(() -> generatedRow(sizeMap, secondTokens));
+        Row secondRow = generatedRow(sizeMap, secondTokens);
         String secondPartition = secondRow.getString(0);
         byte[] secondFilterBytes = (byte[]) secondRow.get(1);
+        BloomFilter rawFilter2 = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream(secondFilterBytes)));
         TeragrepBloomFilter secondFilter = new TeragrepBloomFilter(
                 secondPartition,
-                secondFilterBytes,
+                rawFilter2,
                 lazyConnection.get(),
-                filterSizes
+                filterTypes
         );
         secondFilter.saveFilter(true);
+        String secondSql = "SELECT `filter` FROM `" + tableName + "`";
+        Assertions.assertDoesNotThrow(() -> {
+            ResultSet secondRs = lazyConnection.get().prepareStatement(secondSql).executeQuery();
+            BloomFilter secondResultFilter = emptyFilter;
+            while (secondRs.next()) {
+                byte[] bytes = secondRs.getBytes(1);
+                ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                secondResultFilter = BloomFilter.readFrom(bais);
+            }
+            int secondCols = secondRs.getMetaData().getColumnCount();
 
-        String secondSql = "SELECT `filter` FROM `bloomfilter`;";
-
-        ResultSet secondRs = Assertions
-                .assertDoesNotThrow(() -> lazyConnection.get().prepareStatement(secondSql).executeQuery());
-
-        int secondCols = Assertions.assertDoesNotThrow(() -> secondRs.getMetaData().getColumnCount());
-        BloomFilter secondResultFilter = emptyFilter;
-
-        while (Assertions.assertDoesNotThrow(() -> secondRs.next())) {
-            byte[] bytes = Assertions.assertDoesNotThrow(() -> secondRs.getBytes(1));
-            ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            secondResultFilter = Assertions.assertDoesNotThrow(() -> BloomFilter.readFrom(bais));
-        }
-
-        Assertions.assertNotNull(secondResultFilter);
-        Assertions.assertEquals(1, secondCols);
-        Assertions.assertFalse(secondResultFilter.mightContain("one"));
-        Assertions.assertTrue(secondResultFilter.mightContain("neo"));
-        Assertions.assertTrue(secondResultFilter.expectedFpp() <= 0.01D);
-        Assertions.assertDoesNotThrow(secondRs::close);
-
+            Assertions.assertNotNull(secondResultFilter);
+            Assertions.assertEquals(1, secondCols);
+            Assertions.assertFalse(secondResultFilter.mightContain("one"));
+            Assertions.assertTrue(secondResultFilter.mightContain("neo"));
+            Assertions.assertTrue(secondResultFilter.expectedFpp() <= 0.01D);
+            secondRs.close();
+        });
     }
 
     @Test
-    void correctSizeSelectionTest() {
+    void testCorrectFilterSizeSelection() {
         List<String> tokens = new ArrayList<>();
         tokens.add("one");
         for (int i = 1; i < 1500; i++) {
             tokens.add("token:" + i);
         }
-        Row row = Assertions.assertDoesNotThrow(() -> generatedRow(sizeMap, tokens));
+        Row row = generatedRow(sizeMap, tokens);
         String partition = row.getString(0);
         byte[] filterBytes = (byte[]) row.get(1);
-        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, filterBytes, lazyConnection.get(), filterSizes);
+        BloomFilter rawFilter = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream(filterBytes)));
+        TeragrepBloomFilter filter = new TeragrepBloomFilter(partition, rawFilter, lazyConnection.get(), filterTypes);
         filter.saveFilter(false);
-
         long size = Long.MAX_VALUE;
-
         for (long key : sizeMap.keySet()) {
             if (size > key && key >= tokens.size()) {
                 size = key;
             }
         }
-
         Double fpp = sizeMap.get(size);
-        String sql = "SELECT `filter` FROM `bloomfilter`;";
+        String sql = "SELECT `filter` FROM `" + tableName + "`";
+        Assertions.assertDoesNotThrow(() -> {
+            ResultSet rs = lazyConnection.get().prepareStatement(sql).executeQuery();
+            int cols = rs.getMetaData().getColumnCount();
+            BloomFilter resultFilter = emptyFilter;
+            int loops = 0;
+            while (rs.next()) {
+                loops++;
+                byte[] bytes = rs.getBytes(1);
+                ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                resultFilter = BloomFilter.readFrom(bais);
+            }
+            Assertions.assertEquals(1, loops);
+            Assertions.assertNotNull(resultFilter);
+            Assertions.assertEquals(1, cols);
+            Assertions.assertTrue(resultFilter.mightContain("one"));
+            Assertions.assertFalse(resultFilter.mightContain("neo"));
+            Assertions.assertTrue(resultFilter.expectedFpp() <= fpp);
+            rs.close();
+        });
+    }
 
-        ResultSet rs = Assertions.assertDoesNotThrow(() -> lazyConnection.get().prepareStatement(sql).executeQuery());
+    @Test
+    public void testPatternSavedToDatabase() {
+        String sql = "SELECT `pattern` FROM `filtertype` GROUP BY `pattern`";
+        Assertions.assertDoesNotThrow(() -> {
+            ResultSet rs = lazyConnection.get().prepareStatement(sql).executeQuery();
+            String pattern = "";
+            while (rs.next()) {
+                pattern = rs.getString(1);
+            }
+            Assertions.assertEquals(this.pattern, pattern);
+        });
+    }
 
-        int cols = Assertions.assertDoesNotThrow(() -> rs.getMetaData().getColumnCount());
-        BloomFilter resultFilter = emptyFilter;
+    @Test
+    public void testEquals() {
+        List<String> tokens = new ArrayList<>(Collections.singletonList("one"));
+        Row row = generatedRow(sizeMap, tokens);
+        String partition = row.getString(0);
+        byte[] filterBytes = (byte[]) row.get(1);
+        BloomFilter rawFilter = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream(filterBytes)));
+        TeragrepBloomFilter filter1 = new TeragrepBloomFilter(partition, rawFilter, lazyConnection.get(), filterTypes);
+        TeragrepBloomFilter filter2 = new TeragrepBloomFilter(partition, rawFilter, lazyConnection.get(), filterTypes);
+        filter1.saveFilter(false);
+        Assertions.assertEquals(filter1, filter2);
+    }
 
-        while (Assertions.assertDoesNotThrow(() -> rs.next())) {
-            byte[] bytes = Assertions.assertDoesNotThrow(() -> rs.getBytes(1));
-            ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-            resultFilter = Assertions.assertDoesNotThrow(() -> BloomFilter.readFrom(bais));
-        }
-
-        Assertions.assertNotNull(resultFilter);
-        Assertions.assertEquals(1, cols);
-        Assertions.assertTrue(resultFilter.mightContain("one"));
-        Assertions.assertFalse(resultFilter.mightContain("neo"));
-        Assertions.assertTrue(resultFilter.expectedFpp() <= fpp);
-
-        Assertions.assertDoesNotThrow(rs::close);
+    @Test
+    public void testNotEqualsTokens() {
+        List<String> tokens1 = new ArrayList<>(Collections.singletonList("one"));
+        List<String> tokens2 = new ArrayList<>(Collections.singletonList("two"));
+        Row row1 = generatedRow(sizeMap, tokens1);
+        Row row2 = generatedRow(sizeMap, tokens2);
+        BloomFilter rawFilter1 = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream((byte[]) row1.get(1))));
+        BloomFilter rawFilter2 = Assertions
+                .assertDoesNotThrow(() -> BloomFilter.readFrom(new ByteArrayInputStream((byte[]) row2.get(1))));
+        TeragrepBloomFilter filter1 = new TeragrepBloomFilter(
+                row1.getString(0),
+                rawFilter1,
+                lazyConnection.get(),
+                filterTypes
+        );
+        TeragrepBloomFilter filter2 = new TeragrepBloomFilter(
+                row2.getString(0),
+                rawFilter2,
+                lazyConnection.get(),
+                filterTypes
+        );
+        Assertions.assertNotEquals(filter1, filter2);
     }
 
     // -- Helper methods --
 
-    private Row generatedRow(SortedMap<Long, Double> filterMap, List<String> tokens) throws IOException {
+    private Row generatedRow(SortedMap<Long, Double> filterMap, List<String> tokens) {
         long size = filterMap.lastKey();
-
         for (long key : filterMap.keySet()) {
             if (key < size && key >= tokens.size()) {
                 size = key;
             }
         }
-
         BloomFilter bf = BloomFilter.create(size, filterMap.get(size));
-
-        for (String token : tokens) {
-            bf.put(token);
-        }
-
+        tokens.forEach(bf::put);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        bf.writeTo(baos);
-
+        Assertions.assertDoesNotThrow(() -> {
+            bf.writeTo(baos);
+        });
         return RowFactory.create("1", baos.toByteArray());
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -153,11 +153,14 @@ class TeragrepBloomFilterTest {
             ResultSet rs = lazyConnection.get().prepareStatement(sql).executeQuery();
             int cols = rs.getMetaData().getColumnCount();
             BloomFilter resultFilter = emptyFilter;
+            int loops = 0;
             while (rs.next()) {
                 byte[] bytes = rs.getBytes(1);
                 ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
                 resultFilter = BloomFilter.readFrom(bais);
+                loops++;
             }
+            Assertions.assertEquals(4, loops);
             Assertions.assertNotNull(resultFilter);
             Assertions.assertEquals(1, cols);
             Assertions.assertTrue(resultFilter.mightContain("one"));

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
@@ -1,0 +1,152 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import org.apache.spark.util.sketch.BloomFilter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class ToBloomFilterTest {
+
+    private final List<String> tokens = new ArrayList<>(Arrays.asList("one", "two"));
+    private final byte[] bytes = Assertions.assertDoesNotThrow(() -> {
+        BloomFilter bf = BloomFilter.create(1000, 0.01);
+        tokens.forEach(bf::put);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Assertions.assertDoesNotThrow(() -> {
+            bf.writeTo(baos);
+        });
+        return baos.toByteArray();
+    });
+
+    @Test
+    void testCreation() {
+        Assertions.assertDoesNotThrow(() -> new ToBloomFilter(bytes));
+    }
+
+    @Test
+    void testIsCompatible() {
+        ToBloomFilter filter = new ToBloomFilter(bytes);
+        Assertions.assertTrue(filter.isCompatible(BloomFilter.create(1000, 0.01)));
+        Assertions.assertTrue(filter.isCompatible(new ToBloomFilter(bytes)));
+    }
+
+    @Test
+    void testMerge() {
+        final List<String> secondTokens = new ArrayList<>(Arrays.asList("three", "four"));
+        final byte[] secondBytes = Assertions.assertDoesNotThrow(() -> {
+            BloomFilter bf = BloomFilter.create(1000, 0.01);
+            secondTokens.forEach(bf::put);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Assertions.assertDoesNotThrow(() -> {
+                bf.writeTo(baos);
+            });
+            return baos.toByteArray();
+        });
+        ToBloomFilter filter = new ToBloomFilter(bytes);
+        ToBloomFilter secondFilter = new ToBloomFilter(secondBytes);
+        Assertions.assertTrue(filter.mightContain("one"));
+        Assertions.assertFalse(filter.mightContain("three"));
+        Assertions.assertTrue(secondFilter.mightContain("three"));
+        Assertions.assertFalse(secondFilter.mightContain("one"));
+        Assertions.assertDoesNotThrow(() -> filter.mergeInPlace(secondFilter));
+        Assertions.assertTrue(filter.mightContain("three"));
+    }
+
+    @Test
+    void testIntersectInPlace() {
+        final List<String> secondTokens = new ArrayList<>(Arrays.asList("two", "three"));
+        final byte[] secondBytes = Assertions.assertDoesNotThrow(() -> {
+            BloomFilter bf = BloomFilter.create(1000, 0.01);
+            secondTokens.forEach(bf::put);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Assertions.assertDoesNotThrow(() -> {
+                bf.writeTo(baos);
+            });
+            return baos.toByteArray();
+        });
+        ToBloomFilter filter = new ToBloomFilter(bytes);
+        Assertions.assertTrue(filter.mightContain("one"));
+        Assertions.assertTrue(filter.mightContain("two"));
+        ToBloomFilter secondFilter = new ToBloomFilter(secondBytes);
+        Assertions.assertDoesNotThrow(() -> filter.intersectInPlace(secondFilter));
+        Assertions.assertTrue(filter.mightContain("two"));
+        Assertions.assertFalse(filter.mightContain("one"));
+        Assertions.assertFalse(filter.mightContain("three"));
+    }
+
+    @Test
+    void testEquality() {
+        Assertions.assertEquals(new ToBloomFilter(bytes), new ToBloomFilter(bytes));
+    }
+
+    @Test
+    void testEqualityCacheFilled() {
+        ToBloomFilter filter = new ToBloomFilter(bytes);
+        Assertions.assertTrue(filter.mightContain("one"));
+        Assertions.assertEquals(new ToBloomFilter(bytes), filter);
+    }
+
+    @Test
+    void testNotEquals() {
+        final List<String> secondTokens = new ArrayList<>(Arrays.asList("one", "two", "three"));
+        final byte[] secondBytes = Assertions.assertDoesNotThrow(() -> {
+            BloomFilter bf = BloomFilter.create(1000, 0.01);
+            secondTokens.forEach(bf::put);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Assertions.assertDoesNotThrow(() -> {
+                bf.writeTo(baos);
+            });
+            return baos.toByteArray();
+        });
+        Assertions.assertNotEquals(new ToBloomFilter(bytes), new ToBloomFilter(secondBytes));
+    }
+}


### PR DESCRIPTION
## Adds pattern parameter 
- Gets pattern value in spark.config
- Match pth_06 pattern acceleration schema changes
- Tokenizer uses dpf-03 regex tokenizer to filter tokens using regex from pattern parameter, if no pattern set defaults to normal tokenizer
- Pattern value is added to inserts into filtertype table
- filtertype including pattern is FK to created bloom filter tables 
- Refactoring to comply with company standards
- Object equality and testing
