### PR TITLE
#277: where command does not work as expected with boolean expressions

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
@@ -183,10 +183,6 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
 
         final List<DPLParser.EvalStatementContext> evalStatements = ctx.evalStatement();
 
-        if (evalStatements.size() != 2) {
-            throw new IllegalStateException("Unexpected amount of evalStatements in logic statement, expected <2>, was <" + evalStatements.size() + ">");
-        }
-
         ColumnNode leftSide = (ColumnNode) visit(evalStatements.get(0));
         ColumnNode rightSide = (ColumnNode) visit(evalStatements.get(1));
 

--- a/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
@@ -155,6 +155,17 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
                     rv = new ColumnNode(col.geq(r));
                     break;
                 }
+                case DPLLexer.EVAL_LANGUAGE_MODE_AND: {
+                    rv = new ColumnNode(col.and(r));
+                    break;
+                }
+                case DPLLexer.EVAL_LANGUAGE_MODE_OR: {
+                    rv = new ColumnNode(col.or(r));
+                    break;
+                }
+                default: {
+                    throw new IllegalArgumentException("Unknown operation: " + operation.getSymbol().getText());
+                }
             }
         }
         return (ColumnNode) rv;
@@ -242,8 +253,17 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
                 op = new Token(Type.LE);
                 break;
             }
+            case DPLLexer.EVAL_LANGUAGE_MODE_AND: {
+                op = new Token(Type.AND);
+                break;
+            }
+            case DPLLexer.EVAL_LANGUAGE_MODE_OR: {
+                op = new Token(Type.OR);
+                break;
+            }
             default: {
-                LOGGER.error("Unknown operation: <{}>", operation.getSymbol().getType());
+                LOGGER.error("Unknown operation: <{}>", operation.getSymbol().getText());
+                throw new IllegalArgumentException("Unknown operation: " + operation.getSymbol().getText());
             }
         }
         return op;

--- a/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/EvalStatement.java
@@ -95,82 +95,6 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
         this.catCtx = catCtx;
     }
 
-    /**
-     * Main visitor function for evalStatement
-     * 
-     * @param ctx main parse tree
-     * @return node
-     */
-    public Node visitEvalStatement(DPLParser.EvalStatementContext ctx) {
-        Node rv;
-        LOGGER.info("visitEvalStatement incoming: <{}>", ctx.getText());
-
-        rv = evalStatementEmitCatalyst(ctx);
-        return rv;
-    }
-
-    private Node evalStatementEmitCatalyst(DPLParser.EvalStatementContext ctx) {
-        Node rv = null;
-        Node left = visit(ctx.getChild(0));
-        //if(LOGGER.isDebugEnabled())
-        if (ctx.getChildCount() == 1) {
-            // leaf
-            rv = left;
-        }
-        else if (ctx.getChildCount() == 2) {
-            throw new RuntimeException("Unbalanced evalStatement operation:" + ctx.getText());
-        }
-        else if (ctx.getChildCount() == 3) {
-            // logical operation xxx AND/OR/XOR xxx
-            TerminalNode operation = (TerminalNode) ctx.getChild(1);
-            Token op = getOperation((TerminalNode) ctx.getChild(1));
-            LOGGER.debug("--X visitEvalStatement(catalyst) operation:<{}>", operation.getText().toUpperCase());
-            LOGGER.debug("--X visitEvalStatement(catalyst) op:<{}>", op.getType().toString());
-            Node right = visit(ctx.getChild(2));
-
-            Column col = ((ColumnNode) left).getColumn();
-            Column r = ((ColumnNode) right).getColumn();
-            switch (operation.getSymbol().getType()) {
-                case DPLLexer.EVAL_LANGUAGE_MODE_EQ: {
-                    rv = new ColumnNode(col.equalTo(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_NEQ: {
-                    rv = new ColumnNode(col.notEqual(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_LT: {
-                    rv = new ColumnNode(col.lt(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_LTE: {
-                    rv = new ColumnNode(col.leq(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_GT: {
-                    rv = new ColumnNode(col.gt(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_GTE: {
-                    rv = new ColumnNode(col.geq(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_AND: {
-                    rv = new ColumnNode(col.and(r));
-                    break;
-                }
-                case DPLLexer.EVAL_LANGUAGE_MODE_OR: {
-                    rv = new ColumnNode(col.or(r));
-                    break;
-                }
-                default: {
-                    throw new IllegalArgumentException("Unknown operation: " + operation.getSymbol().getText());
-                }
-            }
-        }
-        return (ColumnNode) rv;
-    }
-
     public Node visitL_evalStatement_subEvalStatement(DPLParser.L_evalStatement_subEvalStatementContext ctx) {
         LOGGER.info("VisitSubEvalStatements: children=<{}> text=<{}>", ctx.getChildCount(), ctx.getChild(0).getText());
         // Consume parenthesis and return actual evalStatement
@@ -221,55 +145,6 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
     }
 
     /**
-     * Converts a {@link TerminalNode} containing an operation into a {@link Token}
-     * 
-     * @param operation TerminalNode of an operation
-     * @return Token
-     */
-    private Token getOperation(TerminalNode operation) {
-        Token op = null;
-        switch (operation.getSymbol().getType()) {
-            case DPLLexer.EVAL_LANGUAGE_MODE_EQ: {
-                op = new Token(Type.EQUALS);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_NEQ: {
-                op = new Token(Type.NOT_EQUALS);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_GT: {
-                op = new Token(Type.GT);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_GTE: {
-                op = new Token(Type.GE);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_LT: {
-                op = new Token(Type.LT);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_LTE: {
-                op = new Token(Type.LE);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_AND: {
-                op = new Token(Type.AND);
-                break;
-            }
-            case DPLLexer.EVAL_LANGUAGE_MODE_OR: {
-                op = new Token(Type.OR);
-                break;
-            }
-            default: {
-                LOGGER.error("Unknown operation: <{}>", operation.getSymbol().getText());
-                throw new IllegalArgumentException("Unknown operation: " + operation.getSymbol().getText());
-            }
-        }
-        return op;
-    }
-
-    /**
      * Generates a column based on a source, value and operation
      * 
      * @param source    Left hand side
@@ -299,55 +174,34 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
     }
 
     private Node evalLogicStatementEmitCatalyst(DPLParser.L_evalStatement_evalLogicStatementContext ctx) {
-        Node rv = null;
-        Column lCol = null;
-        Column rCol = null;
+        final Column col;
         LOGGER
                 .debug(
                         "VisitEvalLogicStatement(Catalyst) incoming: children=<{}> text=<{}>", ctx.getChildCount(),
                         ctx.getText()
                 );
-        Node l = visit(ctx.getChild(0));
-        LOGGER.debug("VisitEvalLogicStatement(Catalyst) left: class=<{}>", l.getClass().getName());
-        if (ctx.getChildCount() == 1) {
-            // leaf
-            rv = l;
-        }
-        else if (ctx.getChildCount() == 2) {
-            // Should not come here at all
-            Node r = visit(ctx.getChild(1));
-            rv = r;
-        }
-        else if (ctx.getChildCount() == 3) {
-            // logical operation xxx AND/OR/XOR xxx
-            TerminalNode op = (TerminalNode) ctx.getChild(1);
-            Token oper = null;
 
-            LOGGER.debug("Operation=<{}> Symbol=<{}> Text=<{}>", op, op.getSymbol(), op.getSymbol().getText());
-            if (op.getSymbol().getType() == DPLLexer.EVAL_LANGUAGE_MODE_AND) {
-                oper = new Token(Type.AND);
-            }
-            if (op.getSymbol().getType() == DPLLexer.EVAL_LANGUAGE_MODE_OR) {
-                oper = new Token(Type.OR);
-            }
-            Node r = visit(ctx.getChild(2));
-            LOGGER.debug("visitEvalLogicStatement(Catalyst) right=<{}>", r.getClass().getName());
+        final List<DPLParser.EvalStatementContext> evalStatements = ctx.evalStatement();
 
-            if (l instanceof ColumnNode && r instanceof ColumnNode) {
-                Column col = null;
-                Column lcol = ((ColumnNode) l).getColumn();
-                Column rcol = ((ColumnNode) r).getColumn();
-                if (op.getSymbol().getType() == DPLLexer.EVAL_LANGUAGE_MODE_AND) {
-                    col = rcol.and(rcol);
-                }
-                if (op.getSymbol().getType() == DPLLexer.EVAL_LANGUAGE_MODE_OR) {
-                    col = lcol.or(rcol);
-                }
-                LOGGER.debug("visitEvalLogicStatement(Catalyst) with oper=<{}>", col.expr().sql());
-                rv = new ColumnNode(col);
-            }
+        if (evalStatements.size() != 2) {
+            throw new IllegalStateException("Unexpected amount of evalStatements in logic statement, expected <2>, was <" + evalStatements.size() + ">");
         }
-        LOGGER.debug(" EvalLogicStatement(Catalyst) generated=<{}> class=<{}>", rv.toString(), rv.getClass().getName());
+
+        ColumnNode leftSide = (ColumnNode) visit(evalStatements.get(0));
+        ColumnNode rightSide = (ColumnNode) visit(evalStatements.get(1));
+
+        if (ctx.EVAL_LANGUAGE_MODE_OR() != null) {
+            col = leftSide.getColumn().or(rightSide.getColumn());
+        }
+        else if (ctx.EVAL_LANGUAGE_MODE_AND() != null) {
+            col = leftSide.getColumn().and(rightSide.getColumn());
+        } else {
+            throw new IllegalArgumentException("Unexpected operation in logic statement: " + ctx.getText());
+        }
+
+
+        final ColumnNode rv = new ColumnNode(col);
+        LOGGER.debug(" EvalLogicStatement(Catalyst) generated=<{}> class=<{}>", rv, rv.getClass().getName());
         return rv;
     }
 
@@ -377,8 +231,8 @@ public class EvalStatement extends DPLParserBaseVisitor<Node> {
 
     @Override
     public Node visitT_eval_evalParameter(DPLParser.T_eval_evalParameterContext ctx) {
-        Node n = visit(ctx.getChild(2));
-        Node field = visit(ctx.getChild(0));
+        Node n = visit(ctx.evalStatement());
+        Node field = visit(ctx.fieldType());
 
         // Step initialization
         this.evalStep = new EvalStep();

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/WhereTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/WhereTransformation.java
@@ -107,7 +107,7 @@ public class WhereTransformation extends DPLParserBaseVisitor<Node> {
         }
 
 
-        Node n = evalStatement.visitEvalStatement(ctx.evalStatement());
+        Node n = evalStatement.visit(ctx.evalStatement());
         String sql = null;
         if (n instanceof ColumnNode) {
             Column whereCol = ((ColumnNode) n).getColumn();

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/WhereTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/WhereTransformation.java
@@ -106,7 +106,8 @@ public class WhereTransformation extends DPLParserBaseVisitor<Node> {
             }
         }
 
-        Node n = evalStatement.visit(ctx.getChild(1));
+
+        Node n = evalStatement.visitEvalStatement(ctx.evalStatement());
         String sql = null;
         if (n instanceof ColumnNode) {
             Column whereCol = ((ColumnNode) n).getColumn();

--- a/src/test/java/com/teragrep/pth10/whereTest.java
+++ b/src/test/java/com/teragrep/pth10/whereTest.java
@@ -149,9 +149,6 @@ public class whereTest {
     }
 
     @Test
-    @Disabled(
-            value = "where command does not work as expected with boolean expressions (especially when combined with > or <), pth-10 issue #277"
-    )
     @DisabledIfSystemProperty(
             named = "skipSparkTest",
             matches = "true"
@@ -180,9 +177,6 @@ public class whereTest {
     }
 
     @Test
-    @Disabled(
-            value = "where command does not work as expected with boolean expressions (especially when combined with > or <), pth-10 issue #277"
-    )
     @DisabledIfSystemProperty(
             named = "skipSparkTest",
             matches = "true"


### PR DESCRIPTION
Changes made:
- Removed unused "visitEvalStatement" from EvalStatement.java
- Replace getChild with evalStatement in WhereTransformation
- Enabled disabled where tests
- Fixed logic in eval logic statement

Related ticket
* #277 