### PR TITLE
exclude test resources: *.jsonl from apache-rat:check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,8 @@
             <exclude>src/test/resources/hdfslist/**</exclude>
             <exclude>src/test/resources/csv/**</exclude>
             <exclude>eclipse-java-formatter.xml</exclude>
+            <!-- jsonl test assets -->
+            <exclude>src/test/resources/**/*.jsonl</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
fixes #367 