### PR TITLE
Add exception handling for bloom option json reading

### DIFF
--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterField.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterField.java
@@ -1,0 +1,94 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import org.apache.spark.util.sketch.BloomFilter;
+
+import java.util.Objects;
+
+public class FilterField {
+
+    private final Long expected;
+    private final Double fpp;
+
+    public FilterField(long expected, double fpp) {
+        this.expected = expected;
+        this.fpp = fpp;
+    }
+
+    public Long expected() {
+        return expected;
+    }
+
+    public int expectedIntValue() {
+        return expected.intValue();
+    }
+
+    public Double fpp() {
+        return fpp;
+    }
+
+    public long bitSize() {
+        return BloomFilter.create(expected, fpp).bitSize();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final FilterField cast = (FilterField) object;
+        return this.expected.equals(cast.expected) && this.fpp.equals(cast.fpp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expected, fpp);
+    }
+}

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterField.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterField.java
@@ -49,7 +49,7 @@ import org.apache.spark.util.sketch.BloomFilter;
 
 import java.util.Objects;
 
-public class FilterField {
+public final class FilterField {
 
     private final Long expected;
     private final Double fpp;

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
@@ -53,6 +53,7 @@ import org.sparkproject.guava.reflect.TypeToken;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public final class FilterTypes implements Serializable {
 
@@ -84,11 +85,16 @@ public final class FilterTypes implements Serializable {
                             + e.getMessage()
             );
         }
+        final boolean hasDuplicates = new HashSet<>(fieldList).size() != fieldList.size();
+        if (hasDuplicates) {
+            throw new RuntimeException("Found duplicate values in 'dpl.pth_06.bloom.db.fields'");
+        }
         return fieldList;
     }
 
     public Map<Long, Long> bitSizeMap() {
         final List<FilterField> fieldList = fieldList();
+        System.out.println(fieldList);
         final Map<Long, Long> bitsizeToExpectedItemsMap = new HashMap<>();
         // Calculate bitSizes
         for (final FilterField field : fieldList) {

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
@@ -46,6 +46,8 @@
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
 import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,7 +55,6 @@ import org.sparkproject.guava.reflect.TypeToken;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public final class FilterTypes implements Serializable {
 
@@ -79,7 +80,7 @@ public final class FilterTypes implements Serializable {
             fieldList = gson.fromJson(sizesJsonString(), new TypeToken<List<FilterField>>() {
             }.getType());
         }
-        catch (Exception e) {
+        catch (JsonIOException | JsonSyntaxException e) {
             throw new RuntimeException(
                     "Error reading 'dpl.pth_06.bloom.db.fields' option to JSON, check that option is formated as JSON array and that there are no duplicate values: "
                             + e.getMessage()
@@ -94,7 +95,6 @@ public final class FilterTypes implements Serializable {
 
     public Map<Long, Long> bitSizeMap() {
         final List<FilterField> fieldList = fieldList();
-        System.out.println(fieldList);
         final Map<Long, Long> bitsizeToExpectedItemsMap = new HashMap<>();
         // Calculate bitSizes
         for (final FilterField field : fieldList) {

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
@@ -60,7 +60,7 @@ class BloomFilterTableTest {
 
     final String username = "sa";
     final String password = "";
-    final String connectionUrl = "jdbc:h2:~/test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+    final String connectionUrl = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
 
     @BeforeAll
     void setEnv() {

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterFieldTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterFieldTest.java
@@ -1,0 +1,87 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import org.apache.spark.util.sketch.BloomFilter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FilterFieldTest {
+
+    @Test
+    public void testBitSize() {
+        long expected = BloomFilter.create(1000, 0.01).bitSize();
+        long result = new FilterField(1000, 0.01).bitSize();
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    public void testEquality() {
+        FilterField field1 = new FilterField(10, 0.01);
+        FilterField field2 = new FilterField(10, 0.01);
+        Assertions.assertEquals(field1, field2);
+    }
+
+    @Test
+    public void testNonEquals() {
+        FilterField field1 = new FilterField(10, 0.01);
+        FilterField field2 = new FilterField(100, 0.01);
+        FilterField field3 = new FilterField(10, 0.02);
+        Assertions.assertNotEquals(field1, field2);
+        Assertions.assertNotEquals(field1, field3);
+    }
+
+    @Test
+    public void testHashCode() {
+        FilterField field1 = new FilterField(10, 0.01);
+        FilterField field2 = new FilterField(10, 0.01);
+        FilterField field3 = new FilterField(11, 0.01);
+        FilterField field4 = new FilterField(10, 0.02);
+        Assertions.assertEquals(field1.hashCode(), field2.hashCode());
+        Assertions.assertNotEquals(field1.hashCode(), field3.hashCode());
+        Assertions.assertNotEquals(field1.hashCode(), field4.hashCode());
+    }
+}

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -103,13 +103,13 @@ class FilterTypesTest {
                 .put(
                         "dpl.pth_06.bloom.db.fields",
                         "[" + "{expected: 1000, fpp: 0.01}," + "{expected: 1000, fpp: 0.01},"
-                                + "{expected: 3000, fpp: 0.01}"
+                                + "{expected: 3000, fpp: 0.01}]"
                 );
         Config config = ConfigFactory.parseProperties(properties);
         FilterTypes filterTypes = new FilterTypes(config);
         RuntimeException exception = assertThrows(RuntimeException.class, filterTypes::fieldList);
-        String expectedError = "Error reading 'dpl.pth_06.bloom.db.fields' option to JSON, check that option is formated as JSON array and that there are no duplicate values: ";
-        Assertions.assertTrue(exception.getMessage().contains(expectedError));
+        String expectedError = "Found duplicate values in 'dpl.pth_06.bloom.db.fields'";
+        Assertions.assertEquals(expectedError, exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -71,6 +71,9 @@ class FilterTypesTest {
         Config config = ConfigFactory.parseProperties(properties);
         FilterTypes filterTypes = new FilterTypes(config);
         List<FilterField> fieldList = filterTypes.fieldList();
+        assertEquals(1000, fieldList.get(0).expected());
+        assertEquals(2000, fieldList.get(1).expected());
+        assertEquals(3000, fieldList.get(2).expected());
         assertEquals(0.01, fieldList.get(0).fpp());
         assertEquals(0.01, fieldList.get(1).fpp());
         assertEquals(0.01, fieldList.get(2).fpp());

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -76,7 +76,7 @@ class TeragrepBloomFilterTest {
         properties.put("dpl.pth_10.bloom.db.username", username);
         String password = "";
         properties.put("dpl.pth_10.bloom.db.password", password);
-        String connectionUrl = "jdbc:h2:~/test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
+        String connectionUrl = "jdbc:h2:mem:test;MODE=MariaDB;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE";
         properties.put("dpl.pth_06.bloom.db.url", connectionUrl);
         properties
                 .put(


### PR DESCRIPTION
- Catch exceptions thrown by gson when reading filter fields option string to JSON
- Use FilterField object to store filter field options `expected` and `fpp` and test
- Get BloomFilter `bitSize` from FilterField object
- Add tests for incorrect JSON fromat in options and duplicate filter field values