### PR TITLE
validate journaldb name when building SQL

### DIFF
--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQL.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQL.java
@@ -57,17 +57,17 @@ public final class TableSQL {
     private final String journalDBName;
     private final boolean ignoreConstraints;
 
-    private void nameIsValid() {
+    private void validSQLName(final String sql) {
         if (ignoreConstraints && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Ignore database constraints active this should be only used in testing");
         }
         final Pattern pattern = Pattern.compile("^[A-Za-z0-9_]+$");
-        if (!pattern.matcher(name).find()) {
-            throw new RuntimeException("dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _");
+        if (!pattern.matcher(sql).find()) {
+            throw new RuntimeException("malformed SQL input <[" + sql + "]>, only use alphabets, numbers and _");
         }
-        if (name.length() > 100) {
+        if (sql.length() > 100) {
             throw new RuntimeException(
-                    "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters"
+                    "SQL input <[" + sql + "]> was too long, allowed maximum length is 100 characters"
             );
         }
     }
@@ -93,7 +93,7 @@ public final class TableSQL {
     }
 
     public String createTableSQL() {
-        nameIsValid();
+        validSQLName(name);
         final String sql;
         if (ignoreConstraints) {
             sql = "CREATE TABLE IF NOT EXISTS `" + name + "`("
@@ -102,6 +102,7 @@ public final class TableSQL {
                     + "`filter` LONGBLOB NOT NULL);";
         }
         else {
+            validSQLName(journalDBName);
             sql = "CREATE TABLE IF NOT EXISTS `" + name + "`("
                     + "`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,"
                     + "`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE," + "`filter_type_id` BIGINT UNSIGNED NOT NULL,"

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
@@ -93,7 +93,8 @@ class BloomFilterTableTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, injectionTable::create);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
+                        "malformed SQL input <[test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')]>, only use alphabets, numbers and _",
+                        e.getMessage()
                 );
     }
 
@@ -107,7 +108,7 @@ class BloomFilterTableTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::create);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        "SQL input <[testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati]> was too long, allowed maximum length is 100 characters",
                         e.getMessage()
                 );
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
@@ -83,10 +83,7 @@ class TableSQLTest {
         String name = "test_table";
         // not validated when ignoreConstraint set to true
         String ignoredInput = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
-        TableSQL table = new TableSQL(
-                name, ignoredInput,
-                true
-        );
+        TableSQL table = new TableSQL(name, ignoredInput, true);
         String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";
         Assertions.assertEquals(e, table.createTableSQL());
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
@@ -67,6 +67,31 @@ class TableSQLTest {
     }
 
     @Test
+    public void testCreateTableSQLInvalidJournalDBOption() {
+        String name = "test_table";
+        TableSQL table = new TableSQL(name, "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')");
+        RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
+        Assertions
+                .assertEquals(
+                        "malformed SQL input <[test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')]>, only use alphabets, numbers and _",
+                        e.getMessage()
+                );
+    }
+
+    @Test
+    public void testCreateTableSQLInvalidJournalDBOptionIgnoreConstraints() {
+        String name = "test_table";
+        TableSQL table = new TableSQL(
+                name,
+                "String e = \"CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL,CONSTRAINT `test_table_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)ON DELETE CASCADE,CONSTRAINT `test_table_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)ON DELETE CASCADE);\";\n"
+                        + "        Assertions.assertEquals(e, table.createTableSQL());",
+                true
+        );
+        String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";
+        Assertions.assertEquals(e, table.createTableSQL());
+    }
+
+    @Test
     public void testIgnoreConstraintsCreateTableSQL() {
         String name = "test_table";
         TableSQL table = new TableSQL(name, true);
@@ -81,7 +106,8 @@ class TableSQLTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
+                        "malformed SQL input <[test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')]>, only use alphabets, numbers and _",
+                        e.getMessage()
                 );
     }
 
@@ -92,7 +118,8 @@ class TableSQLTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name malformed name, only use alphabets, numbers and _", e.getMessage()
+                        "malformed SQL input <[test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')]>, only use alphabets, numbers and _",
+                        e.getMessage()
                 );
     }
 
@@ -103,7 +130,7 @@ class TableSQLTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        "SQL input <[testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati]> was too long, allowed maximum length is 100 characters",
                         e.getMessage()
                 );
     }
@@ -115,7 +142,7 @@ class TableSQLTest {
         RuntimeException e = Assertions.assertThrows(RuntimeException.class, table::createTableSQL);
         Assertions
                 .assertEquals(
-                        "dpl.pth_06.bloom.table.name was too long, allowed maximum length is 100 characters",
+                        "SQL input <[testname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestname_thatistoolongtestnamethati]> was too long, allowed maximum length is 100 characters",
                         e.getMessage()
                 );
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
@@ -81,10 +81,10 @@ class TableSQLTest {
     @Test
     public void testCreateTableSQLInvalidJournalDBOptionIgnoreConstraints() {
         String name = "test_table";
+        // not validated when ignoreConstraint set to true
+        String ignoredInput = "test;%00SELECT%00CONCAT('DROP%00TABLE%00IF%00EXISTS`',table_name,'`;')";
         TableSQL table = new TableSQL(
-                name,
-                "String e = \"CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL,CONSTRAINT `test_table_ibfk_1` FOREIGN KEY (filter_type_id) REFERENCES filtertype (id)ON DELETE CASCADE,CONSTRAINT `test_table_ibfk_2` FOREIGN KEY (partition_id) REFERENCES journaldb.logfile (id)ON DELETE CASCADE);\";\n"
-                        + "        Assertions.assertEquals(e, table.createTableSQL());",
+                name, ignoredInput,
                 true
         );
         String e = "CREATE TABLE IF NOT EXISTS `test_table`(`id` BIGINT UNSIGNED NOT NULL auto_increment PRIMARY KEY,`partition_id` BIGINT UNSIGNED NOT NULL UNIQUE,`filter_type_id` BIGINT UNSIGNED NOT NULL,`filter` LONGBLOB NOT NULL);";


### PR DESCRIPTION
Validate JournalDB SQL name from config option `dpl.pth_06.archive.db.journaldb.name`.
Input can only be 100 characters long and only contain alphabets, numbers or _ symbol. 