### PR TITLE
#282: Fix sourcetype IN not working

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/OrColumn.java
+++ b/src/main/java/com/teragrep/pth10/ast/OrColumn.java
@@ -1,0 +1,44 @@
+package com.teragrep.pth10.ast;
+
+import org.apache.spark.sql.Column;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public final class OrColumn {
+    private final List<Column> columns;
+
+    public OrColumn(Column... columns) {
+        this(Arrays.asList(columns));
+    }
+
+    public OrColumn(List<Column> columns) {
+        this.columns = columns;
+    }
+
+    public Column column() {
+        if (columns.isEmpty()) {
+            throw new IllegalStateException("No columns found");
+        }
+
+        Column rv = columns.get(0);
+        for (Column current : columns.subList(1, columns.size())) {
+            rv = rv.or(current);
+        }
+        return rv;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OrColumn orColumn = (OrColumn) o;
+        return Objects.equals(columns, orColumn.columns);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(columns);
+    }
+}

--- a/src/main/java/com/teragrep/pth10/ast/OrColumn.java
+++ b/src/main/java/com/teragrep/pth10/ast/OrColumn.java
@@ -1,3 +1,48 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
 package com.teragrep.pth10.ast;
 
 import org.apache.spark.sql.Column;
@@ -7,9 +52,10 @@ import java.util.List;
 import java.util.Objects;
 
 public final class OrColumn {
+
     private final List<Column> columns;
 
-    public OrColumn(Column... columns) {
+    public OrColumn(Column ... columns) {
         this(Arrays.asList(columns));
     }
 
@@ -31,8 +77,10 @@ public final class OrColumn {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
         OrColumn orColumn = (OrColumn) o;
         return Objects.equals(columns, orColumn.columns);
     }

--- a/src/main/java/com/teragrep/pth10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -462,16 +462,20 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         }
         else if (left.getSymbol().getType() == DPLLexer.INDEX_IN) {
             OrColumn orColumn = new OrColumn(
-                    ctx.indexStringType().stream().map(st ->
-                            col.rlike(glob2rlike(new UnquotedText(new TextString(st.getText().toLowerCase())).read()))).collect(Collectors.toList())
+                    ctx
+                            .indexStringType()
+                            .stream()
+                            .map(st -> col.rlike(glob2rlike(new UnquotedText(new TextString(st.getText().toLowerCase())).read()))).collect(Collectors.toList())
             );
 
             sQualifier = orColumn.column();
         }
         else if (left.getSymbol().getType() == DPLLexer.SOURCETYPE && operation.getSymbol().getType() == DPLLexer.IN) {
             OrColumn orColumn = new OrColumn(
-                    ctx.stringType().stream().map(st ->
-                            col.rlike(glob2rlike(new UnquotedText(new TextString(st.getText().toLowerCase())).read()))).collect(Collectors.toList())
+                    ctx
+                            .stringType()
+                            .stream()
+                            .map(st -> col.rlike(glob2rlike(new UnquotedText(new TextString(st.getText().toLowerCase())).read()))).collect(Collectors.toList())
             );
 
             sQualifier = orColumn.column();

--- a/src/test/java/com/teragrep/pth10/OrColumnTest.java
+++ b/src/test/java/com/teragrep/pth10/OrColumnTest.java
@@ -1,3 +1,48 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
 package com.teragrep.pth10;
 
 import com.teragrep.pth10.ast.OrColumn;
@@ -6,21 +51,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class OrColumnTest {
+
     @Test
     void testOrColumn() {
-        OrColumn orColumn = new OrColumn(
-                new Column("a"),
-                new Column("b")
-        );
+        OrColumn orColumn = new OrColumn(new Column("a"), new Column("b"));
 
         Assertions.assertEquals(new Column("a").or(new Column("b")), orColumn.column());
     }
 
     @Test
     void testOrColumnWithOneColumn() {
-        OrColumn orColumn = new OrColumn(
-                new Column("a")
-        );
+        OrColumn orColumn = new OrColumn(new Column("a"));
 
         Assertions.assertEquals(new Column("a"), orColumn.column());
     }

--- a/src/test/java/com/teragrep/pth10/OrColumnTest.java
+++ b/src/test/java/com/teragrep/pth10/OrColumnTest.java
@@ -1,0 +1,49 @@
+package com.teragrep.pth10;
+
+import com.teragrep.pth10.ast.OrColumn;
+import org.apache.spark.sql.Column;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class OrColumnTest {
+    @Test
+    void testOrColumn() {
+        OrColumn orColumn = new OrColumn(
+                new Column("a"),
+                new Column("b")
+        );
+
+        Assertions.assertEquals(new Column("a").or(new Column("b")), orColumn.column());
+    }
+
+    @Test
+    void testOrColumnWithOneColumn() {
+        OrColumn orColumn = new OrColumn(
+                new Column("a")
+        );
+
+        Assertions.assertEquals(new Column("a"), orColumn.column());
+    }
+
+    @Test
+    void testOrColumnWithNoColumn() {
+        OrColumn orColumn = new OrColumn();
+
+        IllegalStateException ise = Assertions.assertThrows(IllegalStateException.class, orColumn::column);
+        Assertions.assertEquals("No columns found", ise.getMessage());
+    }
+
+    @Test
+    void testEquals() {
+        OrColumn orColumn = new OrColumn();
+        OrColumn orColumn2 = new OrColumn();
+        Assertions.assertEquals(orColumn, orColumn2);
+    }
+
+    @Test
+    void testNotEquals() {
+        OrColumn orColumn = new OrColumn();
+        OrColumn orColumn2 = new OrColumn(new Column("a"));
+        Assertions.assertNotEquals(orColumn, orColumn2);
+    }
+}

--- a/src/test/java/com/teragrep/pth10/logicalOperationTest.java
+++ b/src/test/java/com/teragrep/pth10/logicalOperationTest.java
@@ -455,8 +455,16 @@ public class logicalOperationTest {
     public void testWithMultipleSourcetypesArchiveAndSparkQuery() {
         String query = "index=index_* sourcetype IN (B:X:0, B:Y:0, C:X:0)";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
-            Assertions.assertEquals("(RLIKE(index, (?i)^index_.*$) AND ((RLIKE(sourcetype, (?i)^b:x:0) OR RLIKE(sourcetype, (?i)^b:y:0)) OR RLIKE(sourcetype, (?i)^c:x:0)))", streamingTestUtil.getCtx().getSparkQuery());
-            Assertions.assertEquals("<AND><index operation=\"EQUALS\" value=\"index_*\"/><OR><OR><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/><sourcetype operation=\"EQUALS\" value=\"b:y:0\"/></OR><sourcetype operation=\"EQUALS\" value=\"c:x:0\"/></OR></AND>", streamingTestUtil.getCtx().getArchiveQuery());
+            Assertions
+                    .assertEquals(
+                            "(RLIKE(index, (?i)^index_.*$) AND ((RLIKE(sourcetype, (?i)^b:x:0) OR RLIKE(sourcetype, (?i)^b:y:0)) OR RLIKE(sourcetype, (?i)^c:x:0)))",
+                            streamingTestUtil.getCtx().getSparkQuery()
+                    );
+            Assertions
+                    .assertEquals(
+                            "<AND><index operation=\"EQUALS\" value=\"index_*\"/><OR><OR><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/><sourcetype operation=\"EQUALS\" value=\"b:y:0\"/></OR><sourcetype operation=\"EQUALS\" value=\"c:x:0\"/></OR></AND>",
+                            streamingTestUtil.getCtx().getArchiveQuery()
+                    );
         });
 
     }
@@ -469,8 +477,16 @@ public class logicalOperationTest {
     public void testWithOneInSourcetypeArchiveAndSparkQuery() {
         String query = "index=index_* sourcetype IN (B:X:0)";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
-            Assertions.assertEquals("(RLIKE(index, (?i)^index_.*$) AND RLIKE(sourcetype, (?i)^b:x:0))", streamingTestUtil.getCtx().getSparkQuery());
-            Assertions.assertEquals("<AND><index operation=\"EQUALS\" value=\"index_*\"/><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/></AND>", streamingTestUtil.getCtx().getArchiveQuery());
+            Assertions
+                    .assertEquals(
+                            "(RLIKE(index, (?i)^index_.*$) AND RLIKE(sourcetype, (?i)^b:x:0))",
+                            streamingTestUtil.getCtx().getSparkQuery()
+                    );
+            Assertions
+                    .assertEquals(
+                            "<AND><index operation=\"EQUALS\" value=\"index_*\"/><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/></AND>",
+                            streamingTestUtil.getCtx().getArchiveQuery()
+                    );
         });
 
     }

--- a/src/test/java/com/teragrep/pth10/logicalOperationTest.java
+++ b/src/test/java/com/teragrep/pth10/logicalOperationTest.java
@@ -422,6 +422,10 @@ public class logicalOperationTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
     public void testWithMultipleSourcetypes() {
         String query = "index=index_* sourcetype IN (B:X:0, B:Y:0, C:X:0)";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
@@ -439,6 +443,34 @@ public class logicalOperationTest {
             Assertions.assertEquals("B:X:0", listOfSourcetype.get(2));
             Assertions.assertEquals("B:X:0", listOfSourcetype.get(3));
             Assertions.assertEquals("C:X:0", listOfSourcetype.get(4));
+        });
+
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    public void testWithMultipleSourcetypesArchiveAndSparkQuery() {
+        String query = "index=index_* sourcetype IN (B:X:0, B:Y:0, C:X:0)";
+        this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
+            Assertions.assertEquals("(RLIKE(index, (?i)^index_.*$) AND ((RLIKE(sourcetype, (?i)^b:x:0) OR RLIKE(sourcetype, (?i)^b:y:0)) OR RLIKE(sourcetype, (?i)^c:x:0)))", streamingTestUtil.getCtx().getSparkQuery());
+            Assertions.assertEquals("<AND><index operation=\"EQUALS\" value=\"index_*\"/><OR><OR><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/><sourcetype operation=\"EQUALS\" value=\"b:y:0\"/></OR><sourcetype operation=\"EQUALS\" value=\"c:x:0\"/></OR></AND>", streamingTestUtil.getCtx().getArchiveQuery());
+        });
+
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    public void testWithOneInSourcetypeArchiveAndSparkQuery() {
+        String query = "index=index_* sourcetype IN (B:X:0)";
+        this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
+            Assertions.assertEquals("(RLIKE(index, (?i)^index_.*$) AND RLIKE(sourcetype, (?i)^b:x:0))", streamingTestUtil.getCtx().getSparkQuery());
+            Assertions.assertEquals("<AND><index operation=\"EQUALS\" value=\"index_*\"/><sourcetype operation=\"EQUALS\" value=\"b:x:0\"/></AND>", streamingTestUtil.getCtx().getArchiveQuery());
         });
 
     }

--- a/src/test/java/com/teragrep/pth10/logicalOperationTest.java
+++ b/src/test/java/com/teragrep/pth10/logicalOperationTest.java
@@ -422,14 +422,11 @@ public class logicalOperationTest {
     }
 
     @Test
-    @Disabled(
-            value = "search does not allow having sourcetype in this format: sourcetype IN (sourcetyp1, sourcetype2), pth-10 issue #282"
-    )
     public void testWithMultipleSourcetypes() {
-        String query = "\"index=index_* sourcetype IN (B:X:0, B:Y:0, C:X:0)\"";
+        String query = "index=index_* sourcetype IN (B:X:0, B:Y:0, C:X:0)";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             List<String> listOfSourcetype = res
-                    .select("_raw")
+                    .select("sourcetype")
                     .orderBy("offset")
                     .collectAsList()
                     .stream()
@@ -437,10 +434,10 @@ public class logicalOperationTest {
                     .collect(Collectors.toList());
 
             Assertions.assertEquals(5, res.count());
-            Assertions.assertEquals("B:X:0", listOfSourcetype.get(0));
-            Assertions.assertEquals("B:X:0", listOfSourcetype.get(1));
-            Assertions.assertEquals("B:Y:0", listOfSourcetype.get(2));
-            Assertions.assertEquals("B:Y:0", listOfSourcetype.get(3));
+            Assertions.assertEquals("B:Y:0", listOfSourcetype.get(0));
+            Assertions.assertEquals("B:Y:0", listOfSourcetype.get(1));
+            Assertions.assertEquals("B:X:0", listOfSourcetype.get(2));
+            Assertions.assertEquals("B:X:0", listOfSourcetype.get(3));
             Assertions.assertEquals("C:X:0", listOfSourcetype.get(4));
         });
 


### PR DESCRIPTION
also cleanup searchQualifier in LogicalStatementCatalyst/XML, enable sourcetype IN test in logicalOperationTest

Test note:
Assertions were changed as they were incorrect for the data used