### PR TITLE
GH#323: Fix syslogStream tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <teragrep.pth_03.version>9.2.0</teragrep.pth_03.version>
     <teragrep.pth_06.version>3.3.2</teragrep.pth_06.version>
     <teragrep.rlp_01.version>4.0.1</teragrep.rlp_01.version>
-    <teragrep.rlp_03.version>1.7.6</teragrep.rlp_03.version>
+    <teragrep.rlp_03.version>9.0.0</teragrep.rlp_03.version>
   </properties>
   <dependencies>
     <!--DPL-dependencies -->

--- a/src/main/java/com/teragrep/pth10/ast/StepList.java
+++ b/src/main/java/com/teragrep/pth10/ast/StepList.java
@@ -237,6 +237,12 @@ public class StepList implements VoidFunction2<Dataset<Row>, Long> {
                 }
             }
 
+            if (step.hasProperty(AbstractStep.CommandProperty.NO_PRECEDING_AGGREGATE)) {
+                if (aggregateCount > 0) {
+                    throw new RuntimeException("Step '" + step + "' cannot be used after aggregations!");
+                }
+            }
+
             if (step.hasProperty(AbstractStep.CommandProperty.SEQUENTIAL_ONLY)) {
                 LOGGER.info("[Analyze] Sequential only command: <{}>", step);
                 // set the breakpoint just once

--- a/src/main/java/com/teragrep/pth10/steps/AbstractStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/AbstractStep.java
@@ -59,7 +59,8 @@ public abstract class AbstractStep {
         IGNORE_DEFAULT_SORTING, // Command applies a certain order to the rows
         SEQUENTIAL_ONLY, // Works only in Sequential mode (forEachBatch)
         AGGREGATE, // If there are multiple aggregate commands, switch to sequential mode is necessary
-        REQUIRE_PRECEDING_AGGREGATE // this command requires an aggregate command before it
+        REQUIRE_PRECEDING_AGGREGATE, // this command requires an aggregate command before it
+        NO_PRECEDING_AGGREGATE // command does not allow an aggregate command before it
     }
 
     protected final Set<CommandProperty> properties = new HashSet<>();

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepSyslogStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepSyslogStep.java
@@ -76,4 +76,9 @@ public class TeragrepSyslogStep extends AbstractStep {
 
         return dataset.map(syslogStreamer, dataset.exprEnc());
     }
+
+    @Override
+    public String toString() {
+        return String.format("TeragrepSyslogStep{relpHost=%s, relpPort=%d}", relpHost, relpPort);
+    }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepSyslogStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepSyslogStep.java
@@ -66,6 +66,7 @@ public class TeragrepSyslogStep extends AbstractStep {
     public TeragrepSyslogStep(String relpHost, int relpPort) {
         this.relpHost = relpHost;
         this.relpPort = relpPort;
+        this.properties.add(CommandProperty.NO_PRECEDING_AGGREGATE);
     }
 
     @Override

--- a/src/test/java/com/teragrep/pth10/SyslogStreamTest.java
+++ b/src/test/java/com/teragrep/pth10/SyslogStreamTest.java
@@ -217,6 +217,10 @@ public class SyslogStreamTest {
                 );
 
         Assertions.assertNotNull(rte);
-        Assertions.assertTrue(rte.getMessage().contains("cannot be used after aggregations!"));
+        Assertions
+                .assertEquals(
+                        rte.getMessage(),
+                        "Step 'TeragrepSyslogStep{relpHost=127.1.0.1, relpPort=9998}' cannot be used after aggregations!"
+                );
     }
 }


### PR DESCRIPTION
Update rlp_03 to 9.0.0; fix syslogStreamTest; add NO_PRECEDING_AGGREGATE CommandProperty to throw error if using syslog stream with preceding aggregate.

fixes:
* #323 

