### PR TITLE
use setLong instead of setInt

### DIFF
--- a/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepBloomStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/TeragrepBloomStep.java
@@ -190,7 +190,7 @@ public final class TeragrepBloomStep extends AbstractStep {
             }
             final String sql = "INSERT IGNORE INTO `filtertype` (`expectedElements`, `targetFpp`, `pattern`) VALUES (?, ?, ?)";
             try (final PreparedStatement stmt = connection.prepareStatement(sql)) {
-                stmt.setInt(1, entry.getKey().intValue()); // filtertype.expectedElements
+                stmt.setLong(1, entry.getKey()); // filtertype.expectedElements
                 stmt.setDouble(2, entry.getValue()); // filtertype.targetFpp
                 stmt.setString(3, pattern); // filtertype.pattern
                 stmt.executeUpdate();

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
@@ -110,8 +110,8 @@ public final class TeragrepBloomFilter {
                         );
                 filter.writeTo(baos);
                 InputStream is = new ByteArrayInputStream(baos.toByteArray());
-                stmt.setInt(1, Integer.parseInt(partitionID)); // bloomfilter.partition_id
-                stmt.setInt(2, (int) selectedExpectedNumOfItems); // filtertype.expectedElements
+                stmt.setLong(1, Long.parseLong(partitionID)); // bloomfilter.partition_id
+                stmt.setLong(2, selectedExpectedNumOfItems); // filtertype.expectedElements
                 stmt.setDouble(3, selectedFpp); // filtertype.targetFpp
                 stmt.setString(4, pattern); // filtertype.pattern
                 stmt.setBlob(5, is); // bloomfilter.filter

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -341,6 +341,6 @@ class TeragrepBloomFilterTest {
         Assertions.assertDoesNotThrow(() -> {
             bf.writeTo(baos);
         });
-        return RowFactory.create("1", baos.toByteArray());
+        return RowFactory.create("9999999999", baos.toByteArray());
     }
 }


### PR DESCRIPTION
- Fix prepared statements that incorrectly used setInt() instead of setLong()
- Update test case to only pass when setLong is used