### PR TITLE
#431: fix EmptyDataframeStep generating non-streaming dataset, add test for…

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/DPLParserCatalystVisitor.java
+++ b/src/main/java/com/teragrep/pth10/ast/DPLParserCatalystVisitor.java
@@ -279,7 +279,7 @@ public class DPLParserCatalystVisitor extends DPLParserBaseVisitor<Node> {
         }
         else {
             // no logical part, e.g. makeresults or similar command in use without main search
-            this.getStepList().add(new EmptyDataframeStep());
+            this.getStepList().add(new EmptyDataframeStep(catCtx));
         }
 
         // Just transform part

--- a/src/main/java/com/teragrep/pth10/steps/EmptyDataframeStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/EmptyDataframeStep.java
@@ -45,9 +45,11 @@
  */
 package com.teragrep.pth10.steps;
 
+import com.teragrep.pth10.ast.DPLParserCatalystContext;
+import com.teragrep.pth10.datasources.GeneratedDatasource;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.streaming.StreamingQueryException;
 
 /**
  * Used to provide a empty dataframe in case of not using a LogicalStatement in the command. For example, the '|
@@ -55,12 +57,19 @@ import org.apache.spark.sql.SparkSession;
  */
 public class EmptyDataframeStep extends AbstractStep {
 
+    private final DPLParserCatalystContext catCtx;
+
+    public EmptyDataframeStep(DPLParserCatalystContext catCtx) {
+        this.catCtx = catCtx;
+    }
+
     @Override
-    public Dataset<Row> get(Dataset<Row> dataset) {
+    public Dataset<Row> get(Dataset<Row> dataset) throws StreamingQueryException {
         if (dataset != null) {
             // this should be in use only without any dataset
             throw new RuntimeException("EmptyDataframeStep was called with a non-null dataframe!");
         }
-        return SparkSession.builder().getOrCreate().emptyDataFrame();
+
+        return new GeneratedDatasource(catCtx).constructEmptyStream();
     }
 }

--- a/src/test/java/com/teragrep/pth10/TeragrepTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/TeragrepTransformationTest.java
@@ -849,6 +849,23 @@ public class TeragrepTransformationTest {
             named = "skipSparkTest",
             matches = "true"
     )
+    public void tgSetConfigLongWithNoLogicalStatementTest() {
+        Config fakeConfig = ConfigFactory
+                .defaultApplication()
+                .withValue("dpl.pth_00.dummy.value", ConfigValueFactory.fromAnyRef(12345));
+        streamingTestUtil.getCtx().setConfig(fakeConfig);
+        Assertions.assertEquals(12345L, streamingTestUtil.getCtx().getConfig().getLong("dpl.pth_00.dummy.value"));
+        streamingTestUtil.performDPLTest(" | teragrep set config dpl.pth_00.dummy.value 99999", testFile, ds -> {
+            Assertions.assertEquals(99999L, streamingTestUtil.getCtx().getConfig().getLong("dpl.pth_00.dummy.value"));
+            Assertions.assertEquals(0, ds.count());
+        });
+    }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
     public void tgSetConfigLongTest() {
         Config fakeConfig = ConfigFactory
                 .defaultApplication()


### PR DESCRIPTION
… issue#431 case

Fixes issue
* #431 

Explanation:
* When logicalStatement or any other dataset generating command is not used, EmptyDataframeStep was used to generate an empty (no results) dataset. However, the step provided a non-streaming dataset. With the changes in this PR, the step will generate a empty streaming dataset.

