### PR TITLE
#439: Only retain current earliest or latest row instead of all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,12 @@
       <artifactId>slf4j-api</artifactId>
       <version>2.0.16</version>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.17.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <directory>${project.basedir}/target</directory>

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/BufferClasses/EarliestLatestBuffer.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/BufferClasses/EarliestLatestBuffer.java
@@ -58,63 +58,30 @@ import java.sql.Timestamp;
  * 
  * @author eemhu
  */
-public class EarliestLatestBuffer implements Serializable {
+public final class EarliestLatestBuffer implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    private CurrentTimestamp earliest = new CurrentTimestampStub();
-    private CurrentTimestamp latest = new CurrentTimestampStub();
-    private Row earliestRow = Row.empty();
-    private Row latestRow = Row.empty();
+    private final CurrentTimestamp earliestTimestamp;
+    private final CurrentTimestamp latestTimestamp;
+    private final Row earliestRow;
+    private final Row latestRow;
     private final String colName;
 
     public EarliestLatestBuffer(final String colName) {
         this.colName = colName;
+        this.earliestTimestamp = new CurrentTimestampStub();
+        this.latestTimestamp = new CurrentTimestampStub();
+        this.earliestRow = Row.empty();
+        this.latestRow = Row.empty();
     }
 
-    /**
-     * Merge two buffers.
-     * 
-     * @param other buffer
-     */
-    public void merge(EarliestLatestBuffer other) {
-        if (this.earliest.isEmpty()) {
-            this.earliest = other.earliest;
-            this.earliestRow = other.earliestRow;
-        }
-
-        if (this.latest.isEmpty()) {
-            this.latest = other.latest;
-            this.latestRow = other.latestRow;
-        }
-
-        if (!other.earliest.isEmpty() && other.earliest.isBefore(this.earliest)) {
-            this.earliest = other.earliest;
-            this.earliestRow = other.earliestRow;
-        }
-
-        if (!other.latest.isEmpty() && other.latest.isAfter(this.latest)) {
-            this.latest = other.latest;
-            this.latestRow = other.latestRow;
-        }
-    }
-
-    /**
-     * Add Time, Data pair
-     * 
-     * @param time key
-     * @param data value
-     */
-    public void add(Timestamp time, Row data) {
-        CurrentTimestamp currentTimestamp = new CurrentTimestampImpl(time);
-        if (this.earliest.isEmpty() || currentTimestamp.isBefore(this.earliest)) {
-            this.earliest = currentTimestamp;
-            this.earliestRow = data;
-        }
-
-        if (this.latest.isEmpty() || currentTimestamp.isAfter(this.latest)) {
-            this.latest = currentTimestamp;
-            this.latestRow = data;
-        }
+    public EarliestLatestBuffer(final String colName, final CurrentTimestamp earliestTimestamp, final CurrentTimestamp latestTimestamp,
+                                final Row earliestRow, final Row latestRow) {
+        this.colName = colName;
+        this.earliestTimestamp = earliestTimestamp;
+        this.latestTimestamp = latestTimestamp;
+        this.earliestRow = earliestRow;
+        this.latestRow = latestRow;
     }
 
     /**
@@ -147,10 +114,10 @@ public class EarliestLatestBuffer implements Serializable {
      * @return field time as unix epoch
      */
     public String earliest_time() {
-        if (earliest.isEmpty()) {
+        if (earliestTimestamp.isEmpty()) {
             return "";
         }
-        return String.valueOf(earliest.timestamp().getTime() / 1000L);
+        return String.valueOf(earliestTimestamp.timestamp().getTime() / 1000L);
     }
 
     /**
@@ -159,10 +126,10 @@ public class EarliestLatestBuffer implements Serializable {
      * @return field time as unix epoch
      */
     public String latest_time() {
-        if (latest.isEmpty()) {
+        if (latestTimestamp.isEmpty()) {
             return "";
         }
-        return String.valueOf(latest.timestamp().getTime() / 1000L);
+        return String.valueOf(latestTimestamp.timestamp().getTime() / 1000L);
     }
 
     /**
@@ -197,5 +164,25 @@ public class EarliestLatestBuffer implements Serializable {
         double rate = dividend / divisor;
 
         return rate;
+    }
+
+    public Row earliestRow() {
+        return earliestRow;
+    }
+
+    public Row latestRow() {
+        return latestRow;
+    }
+
+    public CurrentTimestamp earliestTimestamp() {
+        return earliestTimestamp;
+    }
+
+    public CurrentTimestamp latestTimestamp() {
+        return latestTimestamp;
+    }
+
+    public String colName() {
+        return colName;
     }
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/BufferClasses/EarliestLatestBuffer.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/BufferClasses/EarliestLatestBuffer.java
@@ -46,12 +46,10 @@
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses;
 
 import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestamp;
-import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestampImpl;
 import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestampStub;
 import org.apache.spark.sql.Row;
 
 import java.io.Serializable;
-import java.sql.Timestamp;
 
 /**
  * Java Bean compliant class with helper methods used in EarliestLatestAggregator.java
@@ -75,8 +73,13 @@ public final class EarliestLatestBuffer implements Serializable {
         this.latestRow = Row.empty();
     }
 
-    public EarliestLatestBuffer(final String colName, final CurrentTimestamp earliestTimestamp, final CurrentTimestamp latestTimestamp,
-                                final Row earliestRow, final Row latestRow) {
+    public EarliestLatestBuffer(
+            final String colName,
+            final CurrentTimestamp earliestTimestamp,
+            final CurrentTimestamp latestTimestamp,
+            final Row earliestRow,
+            final Row latestRow
+    ) {
         this.colName = colName;
         this.earliestTimestamp = earliestTimestamp;
         this.latestTimestamp = latestTimestamp;

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestamp.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestamp.java
@@ -45,55 +45,16 @@
  */
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs;
 
-import com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses.EarliestLatestBuffer;
-import org.apache.spark.sql.Encoder;
-import org.apache.spark.sql.Encoders;
-
 import java.io.Serializable;
+import java.sql.Timestamp;
 
-/**
- * Used for rate() function
- */
-public class EarliestLatestAggregator_Double extends EarliestLatestAggregator<Double> implements Serializable {
+public interface CurrentTimestamp extends Serializable {
 
-    private final AggregatorMode.EarliestLatestAggregatorMode mode; // 0=earliest, 1=latest, 2=earliest_time, 3=latest_time, 4=rate
-    private static final long serialVersionUID = 1L;
+    public abstract Timestamp timestamp();
 
-    /**
-     * Initialize with column and mode
-     * 
-     * @param colName column name
-     * @param mode    aggregator mode
-     */
-    public EarliestLatestAggregator_Double(java.lang.String colName, AggregatorMode.EarliestLatestAggregatorMode mode) {
-        super(colName);
-        this.mode = mode;
-    }
+    public abstract boolean isEmpty();
 
-    /**
-     * Output encoder
-     * 
-     * @return double encoder
-     */
-    @Override
-    public Encoder<Double> outputEncoder() {
-        return Encoders.DOUBLE();
-    }
+    public abstract boolean isBefore(CurrentTimestamp other);
 
-    /**
-     * Return the rate
-     * 
-     * @param buffer buffer
-     * @return rate as double
-     */
-    @Override
-    public Double finish(EarliestLatestBuffer buffer) {
-        switch (this.mode) {
-            case RATE: // rate
-                return buffer.rate();
-            default: // shouldn't happen, throw Exception
-                throw new UnsupportedOperationException("EarliestLatestAggregator was called with unsupported mode");
-        }
-    }
-
+    public abstract boolean isAfter(CurrentTimestamp other);
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
@@ -45,55 +45,39 @@
  */
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs;
 
-import com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses.EarliestLatestBuffer;
-import org.apache.spark.sql.Encoder;
-import org.apache.spark.sql.Encoders;
+import java.sql.Timestamp;
 
-import java.io.Serializable;
+public final class CurrentTimestampImpl implements CurrentTimestamp {
 
-/**
- * Used for rate() function
- */
-public class EarliestLatestAggregator_Double extends EarliestLatestAggregator<Double> implements Serializable {
+    private final Timestamp timestamp;
 
-    private final AggregatorMode.EarliestLatestAggregatorMode mode; // 0=earliest, 1=latest, 2=earliest_time, 3=latest_time, 4=rate
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Initialize with column and mode
-     * 
-     * @param colName column name
-     * @param mode    aggregator mode
-     */
-    public EarliestLatestAggregator_Double(java.lang.String colName, AggregatorMode.EarliestLatestAggregatorMode mode) {
-        super(colName);
-        this.mode = mode;
+    public CurrentTimestampImpl(final Timestamp timestamp) {
+        this.timestamp = timestamp;
     }
 
-    /**
-     * Output encoder
-     * 
-     * @return double encoder
-     */
-    @Override
-    public Encoder<Double> outputEncoder() {
-        return Encoders.DOUBLE();
+    public Timestamp timestamp() {
+        return timestamp;
     }
 
-    /**
-     * Return the rate
-     * 
-     * @param buffer buffer
-     * @return rate as double
-     */
+    public boolean isEmpty() {
+        return false;
+    }
+
     @Override
-    public Double finish(EarliestLatestBuffer buffer) {
-        switch (this.mode) {
-            case RATE: // rate
-                return buffer.rate();
-            default: // shouldn't happen, throw Exception
-                throw new UnsupportedOperationException("EarliestLatestAggregator was called with unsupported mode");
+    public boolean isBefore(CurrentTimestamp other) {
+        if (other.isEmpty()) {
+            return false;
         }
+
+        return timestamp.before(other.timestamp());
     }
 
+    @Override
+    public boolean isAfter(CurrentTimestamp other) {
+        if (other.isEmpty()) {
+            return false;
+        }
+
+        return timestamp.after(other.timestamp());
+    }
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
@@ -65,19 +65,11 @@ public final class CurrentTimestampImpl implements CurrentTimestamp {
 
     @Override
     public boolean isBefore(CurrentTimestamp other) {
-        if (other.isEmpty()) {
-            return false;
-        }
-
         return timestamp.before(other.timestamp());
     }
 
     @Override
     public boolean isAfter(CurrentTimestamp other) {
-        if (other.isEmpty()) {
-            return false;
-        }
-
         return timestamp.after(other.timestamp());
     }
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampImpl.java
@@ -46,6 +46,7 @@
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs;
 
 import java.sql.Timestamp;
+import java.util.Objects;
 
 public final class CurrentTimestampImpl implements CurrentTimestamp {
 
@@ -71,5 +72,19 @@ public final class CurrentTimestampImpl implements CurrentTimestamp {
     @Override
     public boolean isAfter(CurrentTimestamp other) {
         return timestamp.after(other.timestamp());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CurrentTimestampImpl that = (CurrentTimestampImpl) o;
+        return Objects.equals(timestamp, that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(timestamp);
     }
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampStub.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/CurrentTimestampStub.java
@@ -45,55 +45,27 @@
  */
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs;
 
-import com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses.EarliestLatestBuffer;
-import org.apache.spark.sql.Encoder;
-import org.apache.spark.sql.Encoders;
+import java.sql.Timestamp;
 
-import java.io.Serializable;
+public final class CurrentTimestampStub implements CurrentTimestamp {
 
-/**
- * Used for rate() function
- */
-public class EarliestLatestAggregator_Double extends EarliestLatestAggregator<Double> implements Serializable {
-
-    private final AggregatorMode.EarliestLatestAggregatorMode mode; // 0=earliest, 1=latest, 2=earliest_time, 3=latest_time, 4=rate
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Initialize with column and mode
-     * 
-     * @param colName column name
-     * @param mode    aggregator mode
-     */
-    public EarliestLatestAggregator_Double(java.lang.String colName, AggregatorMode.EarliestLatestAggregatorMode mode) {
-        super(colName);
-        this.mode = mode;
-    }
-
-    /**
-     * Output encoder
-     * 
-     * @return double encoder
-     */
     @Override
-    public Encoder<Double> outputEncoder() {
-        return Encoders.DOUBLE();
+    public Timestamp timestamp() {
+        throw new UnsupportedOperationException();
     }
 
-    /**
-     * Return the rate
-     * 
-     * @param buffer buffer
-     * @return rate as double
-     */
     @Override
-    public Double finish(EarliestLatestBuffer buffer) {
-        switch (this.mode) {
-            case RATE: // rate
-                return buffer.rate();
-            default: // shouldn't happen, throw Exception
-                throw new UnsupportedOperationException("EarliestLatestAggregator was called with unsupported mode");
-        }
+    public boolean isEmpty() {
+        return true;
     }
 
+    @Override
+    public boolean isBefore(CurrentTimestamp other) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAfter(CurrentTimestamp other) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/EarliestLatestAggregator.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/EarliestLatestAggregator.java
@@ -110,7 +110,6 @@ public abstract class EarliestLatestAggregator<OUT> extends Aggregator<Row, Earl
         Row newEarliestRow = buffer.earliestRow();
         Row newLatestRow = buffer.latestRow();
 
-
         if (buffer.earliestTimestamp().isEmpty()) {
             newEarliest = buffer2.earliestTimestamp();
             newEarliestRow = buffer2.earliestRow();
@@ -157,7 +156,13 @@ public abstract class EarliestLatestAggregator<OUT> extends Aggregator<Row, Earl
     @Override
     public EarliestLatestBuffer reduce(EarliestLatestBuffer buffer, Row input) {
         Timestamp time = getColumnAsTimestamp(input);
-        EarliestLatestBuffer newBuffer = new EarliestLatestBuffer(colName, new CurrentTimestampImpl(time), new CurrentTimestampImpl(time), input, input);
+        EarliestLatestBuffer newBuffer = new EarliestLatestBuffer(
+                colName,
+                new CurrentTimestampImpl(time),
+                new CurrentTimestampImpl(time),
+                input,
+                input
+        );
 
         return merge(buffer, newBuffer);
     }

--- a/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/EarliestLatestAggregator_String.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/aggregate/UDAFs/EarliestLatestAggregator_String.java
@@ -45,7 +45,7 @@
  */
 package com.teragrep.pth10.ast.commands.aggregate.UDAFs;
 
-import com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses.TimestampMapBuffer;
+import com.teragrep.pth10.ast.commands.aggregate.UDAFs.BufferClasses.EarliestLatestBuffer;
 import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.Encoders;
 
@@ -54,9 +54,10 @@ import java.io.Serializable;
 /**
  * Used for earliest, latest, earliest_time, latest_time, rate
  */
-public class EarliestLatestAggregator_String extends EarliestLatestAggregator<String> implements Serializable {
+public final class EarliestLatestAggregator_String extends EarliestLatestAggregator<String> implements Serializable {
 
-    private AggregatorMode.EarliestLatestAggregatorMode mode = AggregatorMode.EarliestLatestAggregatorMode.EARLIEST; // 0=earliest, 1=latest, 2=earliest_time, 3=latest_time, 4=rate
+    private final AggregatorMode.EarliestLatestAggregatorMode mode; // 0=earliest, 1=latest, 2=earliest_time, 3=latest_time, 4=rate
+    private static final long serialVersionUID = 1L;
 
     /**
      * Initialize with column name and mode
@@ -64,12 +65,10 @@ public class EarliestLatestAggregator_String extends EarliestLatestAggregator<St
      * @param colName column name
      * @param mode    aggregator mode
      */
-    public EarliestLatestAggregator_String(java.lang.String colName, AggregatorMode.EarliestLatestAggregatorMode mode) {
+    public EarliestLatestAggregator_String(String colName, AggregatorMode.EarliestLatestAggregatorMode mode) {
         super(colName);
         this.mode = mode;
     }
-
-    private static final long serialVersionUID = 1L;
 
     /**
      * Gets the output encoder
@@ -88,16 +87,16 @@ public class EarliestLatestAggregator_String extends EarliestLatestAggregator<St
      * @return result as a string
      */
     @Override
-    public String finish(TimestampMapBuffer buffer) {
+    public String finish(EarliestLatestBuffer buffer) {
         switch (this.mode) {
             case EARLIEST: // earliest
                 return buffer.earliest();
             case LATEST: // latest
                 return buffer.latest();
             case EARLIEST_TIME: // earliest_time
-                return buffer.earliest_time().toString();
+                return buffer.earliest_time();
             case LATEST_TIME: // latest_time
-                return buffer.latest_time().toString();
+                return buffer.latest_time();
             case RATE: // rate
                 return buffer.rate().toString();
             default: // shouldn't happen, throw Exception

--- a/src/test/java/com/teragrep/pth10/CurrentTimestampTest.java
+++ b/src/test/java/com/teragrep/pth10/CurrentTimestampTest.java
@@ -1,0 +1,109 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10;
+
+import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestamp;
+import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestampImpl;
+import com.teragrep.pth10.ast.commands.aggregate.UDAFs.CurrentTimestampStub;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+public final class CurrentTimestampTest {
+
+    @Test
+    void testCurrentTimestampBeforeAnother() {
+        final CurrentTimestamp currentTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(10000L))
+        );
+        final CurrentTimestamp anotherTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(90000L))
+        );
+        Assertions.assertTrue(currentTimestamp.isBefore(anotherTimestamp));
+        Assertions.assertFalse(currentTimestamp.isAfter(anotherTimestamp));
+    }
+
+    @Test
+    void testCurrentTimestampAfterAnother() {
+        final CurrentTimestamp currentTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(120000L))
+        );
+        final CurrentTimestamp anotherTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(90000L))
+        );
+        Assertions.assertFalse(currentTimestamp.isBefore(anotherTimestamp));
+        Assertions.assertTrue(currentTimestamp.isAfter(anotherTimestamp));
+    }
+
+    @Test
+    void testCurrentTimestampComparingToStub() {
+        final CurrentTimestamp currentTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(10000L))
+        );
+        final CurrentTimestamp anotherTimestamp = new CurrentTimestampStub();
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> currentTimestamp.isBefore(anotherTimestamp));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> currentTimestamp.isAfter(anotherTimestamp));
+    }
+
+    @Test
+    void testStubComparingToCurrentTimestamp() {
+        final CurrentTimestamp currentTimestamp = new CurrentTimestampStub();
+        final CurrentTimestamp anotherTimestamp = new CurrentTimestampImpl(
+                Timestamp.from(Instant.ofEpochSecond(10000L))
+        );
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> currentTimestamp.isBefore(anotherTimestamp));
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> currentTimestamp.isAfter(anotherTimestamp));
+    }
+
+    @Test
+    void testEqualsContract() {
+        EqualsVerifier.forClass(CurrentTimestampImpl.class).verify();
+    }
+
+}

--- a/src/test/java/com/teragrep/pth10/statsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/statsTransformationTest.java
@@ -190,7 +190,6 @@ public class statsTransformationTest {
     void statsTransform_AggEarliest_Test() {
         streamingTestUtil.performDPLTest("index=index_A | stats earliest(offset) AS earliest_offset", testFile, ds -> {
             Assertions.assertEquals("[earliest_offset]", Arrays.toString(ds.columns()));
-
             List<String> destAsList = ds
                     .select("earliest_offset")
                     .collectAsList()

--- a/src/test/java/com/teragrep/pth10/statsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/statsTransformationTest.java
@@ -210,9 +210,7 @@ public class statsTransformationTest {
     void statsTransform_AggEarliestAndLatestCombo_Test() {
         streamingTestUtil.performDPLTest("index=index_A | stats earliest(offset), latest(offset)", testFile, ds -> {
             Assertions.assertEquals("[earliest(offset), latest(offset)]", Arrays.toString(ds.columns()));
-            List<Row> destAsList = ds
-                    .select("earliest(offset)", "latest(offset)")
-                    .collectAsList();
+            List<Row> destAsList = ds.select("earliest(offset)", "latest(offset)").collectAsList();
             Assertions.assertEquals("1", destAsList.get(0).getString(0));
             Assertions.assertEquals("11", destAsList.get(0).getString(1));
         });

--- a/src/test/java/com/teragrep/pth10/statsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/statsTransformationTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth10;
 
+import org.apache.spark.sql.Row;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -197,6 +198,23 @@ public class statsTransformationTest {
                     .map(r -> r.getAs(0).toString())
                     .collect(Collectors.toList());
             Assertions.assertEquals(Collections.singletonList("1"), destAsList);
+        });
+    }
+
+    // Test earliest() and latest() combination
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    void statsTransform_AggEarliestAndLatestCombo_Test() {
+        streamingTestUtil.performDPLTest("index=index_A | stats earliest(offset), latest(offset)", testFile, ds -> {
+            Assertions.assertEquals("[earliest(offset), latest(offset)]", Arrays.toString(ds.columns()));
+            List<Row> destAsList = ds
+                    .select("earliest(offset)", "latest(offset)")
+                    .collectAsList();
+            Assertions.assertEquals("1", destAsList.get(0).getString(0));
+            Assertions.assertEquals("11", destAsList.get(0).getString(1));
         });
     }
 


### PR DESCRIPTION
Fixes issue
* #439 

It was happening with large datasets, most likely cause being all rows were saved into the buffer. In this PR, only the currently earliest / latest row is saved to the buffer. Also the buffer is now immutable and merging logic was moved to the aggregator.