### PR TITLE
Fix bloom translation tests

### DIFF
--- a/src/test/java/com/teragrep/pth10/translationTests/TeragrepTest.java
+++ b/src/test/java/com/teragrep/pth10/translationTests/TeragrepTest.java
@@ -326,7 +326,7 @@ public class TeragrepTest {
 
     @Test
     void testTeragrepBloomCreateTranslation() {
-        final String query = "| teragrep exec bloom create";
+        final String query = "| teragrep exec bloom create table myTable regex \\w{4}";
         final CharStream inputStream = CharStreams.fromString(query);
         final DPLLexer lexer = new DPLLexer(inputStream);
         final DPLParser parser = new DPLParser(new CommonTokenStream(lexer));
@@ -353,7 +353,7 @@ public class TeragrepTest {
 
     @Test
     void testTeragrepBloomUpdateTranslation() {
-        final String query = "| teragrep exec bloom update";
+        final String query = "| teragrep exec bloom update table myTable regex \\w{4}";
         final CharStream inputStream = CharStreams.fromString(query);
         final DPLLexer lexer = new DPLLexer(inputStream);
         final DPLParser parser = new DPLParser(new CommonTokenStream(lexer));


### PR DESCRIPTION
Fixes #443 .

Bloom translation tests did not include the table and regex parameters that were moved from spark config to dpl language earlier, which caused two tests to fail. Added the missing parameters to the test queries.

Would like to improve these tests in the future, currently they just test that the bloom mode is correct. Making all fields public for translationTests (like elsewhere) doesn't seem too smart, so overriding equals and hashcode methods would be the best option. Creating equality tests is another challenge as steps aren't immutable currently because of the AbstractStep class. So, a refactoring should be done for Steps. I'll make some issues about these problems.