### PR TITLE
BloomFilter equals tests and refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <version>3.17.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.teragrep</groupId>
       <artifactId>pth_06</artifactId>
       <version>${teragrep.pth_06.version}</version>

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/TeragrepTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/TeragrepTransformation.java
@@ -53,7 +53,7 @@ import com.teragrep.pth10.ast.bo.StringNode;
 import com.teragrep.pth10.ast.bo.Token;
 import com.teragrep.pth10.ast.commands.logicalstatement.LogicalStatementCatalyst;
 import com.teragrep.pth10.ast.commands.logicalstatement.LogicalStatementXML;
-import com.teragrep.pth10.ast.commands.transformstatement.teragrep.ModeFromBloomContext;
+import com.teragrep.pth10.ast.commands.transformstatement.teragrep.ContextBloomMode;
 import com.teragrep.pth10.ast.commands.transformstatement.teragrep.EstimateColumnFromBloomContext;
 import com.teragrep.pth10.ast.commands.transformstatement.teragrep.InputColumnFromBloomContext;
 import com.teragrep.pth10.ast.commands.transformstatement.teragrep.OutputColumnFromBloomContext;
@@ -480,7 +480,7 @@ public class TeragrepTransformation extends DPLParserBaseVisitor<Node> {
     @Override
     public Node visitT_bloomOptionParameter(final DPLParser.T_bloomOptionParameterContext ctx) {
         // values from context
-        final ContextValue<TeragrepBloomStep.BloomMode> mode = new ModeFromBloomContext(ctx);
+        final ContextValue<TeragrepBloomStep.BloomMode> mode = new ContextBloomMode(ctx);
         final ContextValue<String> inputCol = new InputColumnFromBloomContext(ctx);
         final ContextValue<String> outputCol = new OutputColumnFromBloomContext(ctx, inputCol.value());
         final ContextValue<String> estimateCol = new EstimateColumnFromBloomContext(ctx, inputCol.value());

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/teragrep/ContextBloomMode.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/teragrep/ContextBloomMode.java
@@ -49,11 +49,11 @@ import com.teragrep.pth10.ast.ContextValue;
 import com.teragrep.pth10.steps.teragrep.TeragrepBloomStep;
 import com.teragrep.pth_03.antlr.DPLParser;
 
-public final class ModeFromBloomContext implements ContextValue<TeragrepBloomStep.BloomMode> {
+public final class ContextBloomMode implements ContextValue<TeragrepBloomStep.BloomMode> {
 
     private final DPLParser.T_bloomOptionParameterContext ctx;
 
-    public ModeFromBloomContext(final DPLParser.T_bloomOptionParameterContext ctx) {
+    public ContextBloomMode(final DPLParser.T_bloomOptionParameterContext ctx) {
         this.ctx = ctx;
     }
 

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterBlob.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterBlob.java
@@ -56,15 +56,15 @@ import java.util.Arrays;
  * 
  * @see TeragrepBloomFilter
  */
-public final class ToBloomFilter {
+public final class BloomFilterBlob {
 
     private final byte[] bytes;
 
-    public ToBloomFilter(final byte[] bytes) {
+    public BloomFilterBlob(final byte[] bytes) {
         this.bytes = bytes;
     }
 
-    public BloomFilter fromBytes() {
+    public BloomFilter toBloomFilter() {
         final BloomFilter filter;
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
             filter = BloomFilter.readFrom(bais);
@@ -83,7 +83,7 @@ public final class ToBloomFilter {
             return false;
         if (object.getClass() != this.getClass())
             return false;
-        final ToBloomFilter cast = (ToBloomFilter) object;
+        final BloomFilterBlob cast = (BloomFilterBlob) object;
         return Arrays.equals(this.bytes, cast.bytes);
     }
 

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunction.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunction.java
@@ -51,6 +51,7 @@ import org.apache.spark.sql.Row;
 
 import java.sql.Connection;
 import java.util.Iterator;
+import java.util.Objects;
 
 public final class BloomFilterForeachPartitionFunction implements ForeachPartitionFunction<Row> {
 
@@ -100,5 +101,19 @@ public final class BloomFilterForeachPartitionFunction implements ForeachPartiti
             tgFilter.saveFilter(overwrite);
             conn.commit();
         }
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        final BloomFilterForeachPartitionFunction cast = (BloomFilterForeachPartitionFunction) o;
+        return filterTypes.equals(cast.filterTypes) && lazyConnection.equals(cast.lazyConnection)
+                && overwrite == cast.overwrite && tableName.equals(cast.tableName) && regex.equals(cast.regex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filterTypes, lazyConnection, overwrite, tableName, regex);
     }
 }

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
@@ -79,7 +79,7 @@ public final class TeragrepBloomFilter {
             String tableName,
             String regex
     ) {
-        this(partition, new ToBloomFilter(bytes).fromBytes(), connection, filterTypes, tableName, regex);
+        this(partition, new BloomFilterBlob(bytes).toBloomFilter(), connection, filterTypes, tableName, regex);
     }
 
     public TeragrepBloomFilter(

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilter.java
@@ -79,7 +79,7 @@ public final class TeragrepBloomFilter {
             String tableName,
             String regex
     ) {
-        this(partition, new ToBloomFilter(bytes), connection, filterTypes, tableName, regex);
+        this(partition, new ToBloomFilter(bytes).fromBytes(), connection, filterTypes, tableName, regex);
     }
 
     public TeragrepBloomFilter(

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterBlobTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterBlobTest.java
@@ -55,7 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class ToBloomFilterTest {
+public class BloomFilterBlobTest {
 
     private final List<String> tokens = new ArrayList<>(Arrays.asList("one", "two"));
     private final byte[] bytes = Assertions.assertDoesNotThrow(() -> {
@@ -70,14 +70,14 @@ public class ToBloomFilterTest {
 
     @Test
     void testCreation() {
-        Assertions.assertDoesNotThrow(() -> new ToBloomFilter(bytes));
+        Assertions.assertDoesNotThrow(() -> new BloomFilterBlob(bytes));
     }
 
     @Test
     void testIsCompatible() {
-        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
+        BloomFilter filter = new BloomFilterBlob(bytes).toBloomFilter();
         Assertions.assertTrue(filter.isCompatible(BloomFilter.create(1000, 0.01)));
-        Assertions.assertTrue(filter.isCompatible(new ToBloomFilter(bytes).fromBytes()));
+        Assertions.assertTrue(filter.isCompatible(new BloomFilterBlob(bytes).toBloomFilter()));
     }
 
     @Test
@@ -92,8 +92,8 @@ public class ToBloomFilterTest {
             });
             return baos.toByteArray();
         });
-        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
-        BloomFilter secondFilter = new ToBloomFilter(secondBytes).fromBytes();
+        BloomFilter filter = new BloomFilterBlob(bytes).toBloomFilter();
+        BloomFilter secondFilter = new BloomFilterBlob(secondBytes).toBloomFilter();
         Assertions.assertTrue(filter.mightContain("one"));
         Assertions.assertFalse(filter.mightContain("three"));
         Assertions.assertTrue(secondFilter.mightContain("three"));
@@ -114,10 +114,10 @@ public class ToBloomFilterTest {
             });
             return baos.toByteArray();
         });
-        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
+        BloomFilter filter = new BloomFilterBlob(bytes).toBloomFilter();
         Assertions.assertTrue(filter.mightContain("one"));
         Assertions.assertTrue(filter.mightContain("two"));
-        BloomFilter secondFilter = new ToBloomFilter(secondBytes).fromBytes();
+        BloomFilter secondFilter = new BloomFilterBlob(secondBytes).toBloomFilter();
         Assertions.assertDoesNotThrow(() -> filter.intersectInPlace(secondFilter));
         Assertions.assertTrue(filter.mightContain("two"));
         Assertions.assertFalse(filter.mightContain("one"));
@@ -126,14 +126,14 @@ public class ToBloomFilterTest {
 
     @Test
     void testEquality() {
-        Assertions.assertEquals(new ToBloomFilter(bytes), new ToBloomFilter(bytes));
+        Assertions.assertEquals(new BloomFilterBlob(bytes), new BloomFilterBlob(bytes));
     }
 
     @Test
     void testEqualityCacheFilled() {
-        ToBloomFilter filter = new ToBloomFilter(bytes);
-        Assertions.assertTrue(filter.fromBytes().mightContain("one"));
-        Assertions.assertEquals(new ToBloomFilter(bytes), filter);
+        BloomFilterBlob filter = new BloomFilterBlob(bytes);
+        Assertions.assertTrue(filter.toBloomFilter().mightContain("one"));
+        Assertions.assertEquals(new BloomFilterBlob(bytes), filter);
     }
 
     @Test
@@ -148,11 +148,11 @@ public class ToBloomFilterTest {
             });
             return baos.toByteArray();
         });
-        Assertions.assertNotEquals(new ToBloomFilter(bytes), new ToBloomFilter(secondBytes));
+        Assertions.assertNotEquals(new BloomFilterBlob(bytes), new BloomFilterBlob(secondBytes));
     }
 
     @Test
     void testEqualsVerifier() {
-        EqualsVerifier.forClass(ToBloomFilter.class).withNonnullFields("bytes").verify();
+        EqualsVerifier.forClass(BloomFilterBlob.class).withNonnullFields("bytes").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunctionTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunctionTest.java
@@ -45,50 +45,15 @@
  */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
-import org.apache.spark.util.sketch.BloomFilter;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Arrays;
+public class BloomFilterForeachPartitionFunctionTest {
 
-/**
- * BloomFilter from byte[] used in a constructor of TeragrepBloomFilter
- * 
- * @see TeragrepBloomFilter
- */
-public final class ToBloomFilter {
-
-    private final byte[] bytes;
-
-    public ToBloomFilter(final byte[] bytes) {
-        this.bytes = bytes;
-    }
-
-    public BloomFilter fromBytes() {
-        final BloomFilter filter;
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-            filter = BloomFilter.readFrom(bais);
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Error reading bytes to filter: " + e.getMessage());
-        }
-        return filter;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object)
-            return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
-            return false;
-        final ToBloomFilter cast = (ToBloomFilter) object;
-        return Arrays.equals(this.bytes, cast.bytes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(bytes);
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier
+                .forClass(BloomFilterForeachPartitionFunction.class)
+                .withNonnullFields("filterTypes", "lazyConnection", "overwrite", "tableName", "regex");
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunctionTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterForeachPartitionFunctionTest.java
@@ -54,6 +54,7 @@ public class BloomFilterForeachPartitionFunctionTest {
     public void testEqualsVerifier() {
         EqualsVerifier
                 .forClass(BloomFilterForeachPartitionFunction.class)
-                .withNonnullFields("filterTypes", "lazyConnection", "overwrite", "tableName", "regex");
+                .withNonnullFields("filterTypes", "lazyConnection", "overwrite", "tableName", "regex")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterTableTest.java
@@ -47,6 +47,7 @@ package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.*;
 
 import java.sql.Connection;
@@ -180,6 +181,11 @@ public class BloomFilterTableTest {
         BloomFilterTable table2 = new BloomFilterTable(config, tableName, false);
         table1.create();
         Assertions.assertNotEquals(table1, table2);
+    }
+
+    @Test
+    void testEqualsVerifier() {
+        EqualsVerifier.forClass(BloomFilterTable.class).withNonnullFields("tableSQL", "conn").verify();
     }
 
     private Properties getDefaultProperties() {

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -47,6 +47,7 @@ package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -168,6 +169,11 @@ class FilterTypesTest {
         FilterTypes filterTypes1 = new FilterTypes(config1);
         FilterTypes filterTypes2 = new FilterTypes(config2);
         assertNotEquals(filterTypes1, filterTypes2);
+    }
+
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier.forClass(FilterTypes.class).withNonnullFields("config").verify();
     }
 
     public Properties defaultProperties() {

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/JournalDBNameFromConfigTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/JournalDBNameFromConfigTest.java
@@ -45,50 +45,13 @@
  */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
-import org.apache.spark.util.sketch.BloomFilter;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Arrays;
+public class JournalDBNameFromConfigTest {
 
-/**
- * BloomFilter from byte[] used in a constructor of TeragrepBloomFilter
- * 
- * @see TeragrepBloomFilter
- */
-public final class ToBloomFilter {
-
-    private final byte[] bytes;
-
-    public ToBloomFilter(final byte[] bytes) {
-        this.bytes = bytes;
-    }
-
-    public BloomFilter fromBytes() {
-        final BloomFilter filter;
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-            filter = BloomFilter.readFrom(bais);
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Error reading bytes to filter: " + e.getMessage());
-        }
-        return filter;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object)
-            return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
-            return false;
-        final ToBloomFilter cast = (ToBloomFilter) object;
-        return Arrays.equals(this.bytes, cast.bytes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(bytes);
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier.forClass(JournalDBNameFromConfig.class).withNonnullFields("config").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnectionTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/LazyConnectionTest.java
@@ -45,50 +45,13 @@
  */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
-import org.apache.spark.util.sketch.BloomFilter;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Arrays;
+public class LazyConnectionTest {
 
-/**
- * BloomFilter from byte[] used in a constructor of TeragrepBloomFilter
- * 
- * @see TeragrepBloomFilter
- */
-public final class ToBloomFilter {
-
-    private final byte[] bytes;
-
-    public ToBloomFilter(final byte[] bytes) {
-        this.bytes = bytes;
-    }
-
-    public BloomFilter fromBytes() {
-        final BloomFilter filter;
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-            filter = BloomFilter.readFrom(bais);
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Error reading bytes to filter: " + e.getMessage());
-        }
-        return filter;
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-        if (this == object)
-            return true;
-        if (object == null)
-            return false;
-        if (object.getClass() != this.getClass())
-            return false;
-        final ToBloomFilter cast = (ToBloomFilter) object;
-        return Arrays.equals(this.bytes, cast.bytes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(bytes);
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier.forClass(LazyConnection.class).withNonnullFields("config").verify();
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TableSQLTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -164,5 +165,13 @@ class TableSQLTest {
         TableSQL table1 = new TableSQL("table_1", true);
         TableSQL table2 = new TableSQL("table_2");
         Assertions.assertNotEquals(table1, table2);
+    }
+
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier
+                .forClass(TableSQL.class)
+                .withNonnullFields("validPattern", "name", "journalDBName", "ignoreConstraints")
+                .verify();
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -370,7 +370,8 @@ class TeragrepBloomFilterTest {
     public void testEqualsVerifier() {
         EqualsVerifier
                 .forClass(TeragrepBloomFilter.class)
-                .withNonnullFields("partitionID", "filter", "connection", "filterTypes", "tableName", "regex");
+                .withNonnullFields("partitionID", "filter", "connection", "filterTypes", "tableName", "regex")
+                .verify();
     }
 
     // -- Helper methods --

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/TeragrepBloomFilterTest.java
@@ -47,6 +47,7 @@ package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.util.sketch.BloomFilter;
@@ -363,6 +364,13 @@ class TeragrepBloomFilterTest {
                 pattern
         );
         Assertions.assertNotEquals(filter1, filter2);
+    }
+
+    @Test
+    public void testEqualsVerifier() {
+        EqualsVerifier
+                .forClass(TeragrepBloomFilter.class)
+                .withNonnullFields("partitionID", "filter", "connection", "filterTypes", "tableName", "regex");
     }
 
     // -- Helper methods --

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
@@ -132,7 +132,7 @@ public class ToBloomFilterTest {
     @Test
     void testEqualityCacheFilled() {
         ToBloomFilter filter = new ToBloomFilter(bytes);
-        filter.fromBytes();
+        Assertions.assertTrue(filter.fromBytes().mightContain("one"));
         Assertions.assertEquals(new ToBloomFilter(bytes), filter);
     }
 

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/ToBloomFilterTest.java
@@ -45,6 +45,7 @@
  */
 package com.teragrep.pth10.steps.teragrep.bloomfilter;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.spark.util.sketch.BloomFilter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-class ToBloomFilterTest {
+public class ToBloomFilterTest {
 
     private final List<String> tokens = new ArrayList<>(Arrays.asList("one", "two"));
     private final byte[] bytes = Assertions.assertDoesNotThrow(() -> {
@@ -74,9 +75,9 @@ class ToBloomFilterTest {
 
     @Test
     void testIsCompatible() {
-        ToBloomFilter filter = new ToBloomFilter(bytes);
+        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
         Assertions.assertTrue(filter.isCompatible(BloomFilter.create(1000, 0.01)));
-        Assertions.assertTrue(filter.isCompatible(new ToBloomFilter(bytes)));
+        Assertions.assertTrue(filter.isCompatible(new ToBloomFilter(bytes).fromBytes()));
     }
 
     @Test
@@ -91,8 +92,8 @@ class ToBloomFilterTest {
             });
             return baos.toByteArray();
         });
-        ToBloomFilter filter = new ToBloomFilter(bytes);
-        ToBloomFilter secondFilter = new ToBloomFilter(secondBytes);
+        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
+        BloomFilter secondFilter = new ToBloomFilter(secondBytes).fromBytes();
         Assertions.assertTrue(filter.mightContain("one"));
         Assertions.assertFalse(filter.mightContain("three"));
         Assertions.assertTrue(secondFilter.mightContain("three"));
@@ -113,10 +114,10 @@ class ToBloomFilterTest {
             });
             return baos.toByteArray();
         });
-        ToBloomFilter filter = new ToBloomFilter(bytes);
+        BloomFilter filter = new ToBloomFilter(bytes).fromBytes();
         Assertions.assertTrue(filter.mightContain("one"));
         Assertions.assertTrue(filter.mightContain("two"));
-        ToBloomFilter secondFilter = new ToBloomFilter(secondBytes);
+        BloomFilter secondFilter = new ToBloomFilter(secondBytes).fromBytes();
         Assertions.assertDoesNotThrow(() -> filter.intersectInPlace(secondFilter));
         Assertions.assertTrue(filter.mightContain("two"));
         Assertions.assertFalse(filter.mightContain("one"));
@@ -131,7 +132,7 @@ class ToBloomFilterTest {
     @Test
     void testEqualityCacheFilled() {
         ToBloomFilter filter = new ToBloomFilter(bytes);
-        Assertions.assertTrue(filter.mightContain("one"));
+        filter.fromBytes();
         Assertions.assertEquals(new ToBloomFilter(bytes), filter);
     }
 
@@ -148,5 +149,10 @@ class ToBloomFilterTest {
             return baos.toByteArray();
         });
         Assertions.assertNotEquals(new ToBloomFilter(bytes), new ToBloomFilter(secondBytes));
+    }
+
+    @Test
+    void testEqualsVerifier() {
+        EqualsVerifier.forClass(ToBloomFilter.class).withNonnullFields("bytes").verify();
     }
 }


### PR DESCRIPTION
Fixes #440 .

- Adds equalsVerifier tests. TeragrepBloomStep didn't get one, see issue #446 . Also objects that take a Context object as a parameter (from ANTLR) didn't work with equalsVerifier.
- Renamed ModeFromBloomContext to ContextBloomMode.
- Refactored ToBloomFilter. In #440, it was asked to fix hashCode and equals functions. The cache was mutable however, so equals tests didn't work. Refactored it so that it no longer extends BloomFilter, just offers the function to create a BloomFilter from bytes (originally that function was called first, creating a BloomFilter and then delegating function calls to the BloomFilter). I think this made the object simpler.