### PR TITLE
#435: logicalStatement latest does not apply correctly with second fractions

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/DPLParserConfig.java
+++ b/src/main/java/com/teragrep/pth10/ast/DPLParserConfig.java
@@ -111,7 +111,7 @@ public class DPLParserConfig {
         // Try to check if it is relative and catch exception
         try {
             RelativeTimestamp rtTimestamp = rtParser.parse(earliest); // can throw error if not relative timestamp
-            earliestEpoch = rtTimestamp.calculate(now);
+            earliestEpoch = rtTimestamp.calculate(now).getEpochSecond();
         }
         catch (NumberFormatException ne) {
             // absolute time
@@ -145,7 +145,7 @@ public class DPLParserConfig {
         // Try to check if it is relative and catch exception
         try {
             RelativeTimestamp rtTimestamp = rtParser.parse(latest); // can throw exception if not relative timestamp
-            latestEpoch = rtTimestamp.calculate(now);
+            latestEpoch = rtTimestamp.calculate(now).getEpochSecond();
         }
         catch (NumberFormatException ne) {
             // absolute time

--- a/src/main/java/com/teragrep/pth10/ast/DPLTimeFormat.java
+++ b/src/main/java/com/teragrep/pth10/ast/DPLTimeFormat.java
@@ -47,6 +47,7 @@ package com.teragrep.pth10.ast;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 
 /**
  * For using the DPL custom timeformat like Java's SimpleDateFormat. Get a Date object with parse -function for example.
@@ -78,8 +79,8 @@ public final class DPLTimeFormat {
      * @return Unix Epoch
      * @throws ParseException when dplTime doesn't have the correct format
      */
-    public long getEpoch(String dplTime) throws ParseException {
-        return createSimpleDateFormat().parse(dplTime).getTime() / 1000L;
+    public Instant instantOf(String dplTime) throws ParseException {
+        return createSimpleDateFormat().parse(dplTime).toInstant();
     }
 
     // replace dpl time units with java-compatible time units

--- a/src/main/java/com/teragrep/pth10/ast/DefaultTimeFormat.java
+++ b/src/main/java/com/teragrep/pth10/ast/DefaultTimeFormat.java
@@ -56,6 +56,22 @@ import java.util.Date;
  */
 public class DefaultTimeFormat {
 
+    private final String[] formats;
+
+    public DefaultTimeFormat() {
+        this(new String[] {
+                "MM/dd/yyyy:HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+                "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                "yyyy-MM-dd'T'HH:mm:ssXXX",
+                "yyyy-MM-dd'T'HH:mm:ss"
+        });
+    }
+
+    public DefaultTimeFormat(String[] formats) {
+        this.formats = formats;
+    }
+
     /**
      * Calculate the epoch from given string.
      * 
@@ -73,40 +89,15 @@ public class DefaultTimeFormat {
      * @return Date parsed from the given string
      */
     public Date parse(String time) {
-        // Try parsing all the three default timeformats
-        Date date;
-
-        int attempt = 0;
-        while (true) {
+        // Try parsing all provided time formats in order
+        for (final String format : formats) {
             try {
-                if (attempt == 0) {
-                    // Use default format (MM/dd/yyyy:HH:mm:ss)
-                    // Use system default timezone
-                    date = this.parseDate(time, "MM/dd/yyyy:HH:mm:ss");
-                }
-                else if (attempt == 1) {
-                    // On first fail, try ISO 8601 with timezone offset, e.g. '2011-12-03T10:15:30+01:00'
-                    date = this.parseDate(time, "yyyy-MM-dd'T'HH:mm:ssXXX");
-                }
-                else {
-                    // On second fail, try ISO 8601 without offset, e.g. '2011-12-03T10:15:30'
-                    // Use system default timezone
-                    date = this.parseDate(time, "yyyy-MM-dd'T'HH:mm:ss");
-                }
-                break;
-
+                return parseDate(time, format);
             }
-            catch (ParseException e) {
-                if (attempt > 1) {
-                    throw new RuntimeException("TimeQualifier conversion error: <" + time + "> can't be parsed.");
-                }
-            }
-            finally {
-                attempt++;
+            catch (ParseException ignored) {
             }
         }
-
-        return date;
+        throw new RuntimeException("TimeQualifier conversion error: <" + time + "> can't be parsed.");
     }
 
     private Date parseDate(String time, String timeFormat) throws ParseException {

--- a/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/UDFs/Mvrange.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/evalstatement/UDFs/Mvrange.java
@@ -106,7 +106,7 @@ public class Mvrange implements UDF3<Integer, Integer, Object, List<String>>, Se
             RelativeTimestamp rtTimestamp = rtParser.parse("+" + stepStr);
             // Go until incremented past end
             while (time < end) {
-                time = rtTimestamp.calculate(new Timestamp(time * 1000L));
+                time = rtTimestamp.calculate(new Timestamp(time * 1000L)).getEpochSecond();
 
                 // If time went past end, stop incrementing and don't add to mv field
                 if (time > end) {

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/convert/Mktime.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/convert/Mktime.java
@@ -61,7 +61,7 @@ public class Mktime implements UDF2<String, String, String> {
     @Override
     public String call(String hrt, String tf) throws Exception {
         DPLTimeFormat format = new DPLTimeFormat(tf);
-        Long rv = format.getEpoch(hrt);
+        Long rv = format.instantOf(hrt).getEpochSecond();
 
         return rv.toString();
     }

--- a/src/main/java/com/teragrep/pth10/ast/time/DPLTimestamp.java
+++ b/src/main/java/com/teragrep/pth10/ast/time/DPLTimestamp.java
@@ -43,29 +43,11 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth10.ast.commands.evalstatement.UDFs;
+package com.teragrep.pth10.ast.time;
 
-import com.teragrep.pth10.ast.time.RelativeTimeParser;
-import com.teragrep.pth10.ast.time.RelativeTimestamp;
-import org.apache.spark.sql.api.java.UDF2;
+import java.time.Instant;
 
-import java.io.Serializable;
-import java.sql.Timestamp;
+public interface DPLTimestamp {
 
-/**
- * UDF for command relative_time(unixtime, modifier)<br>
- * 
- * @author eemhu
- */
-public class Relative_time implements UDF2<Long, String, Long>, Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public Long call(Long unixtime, String modifier) throws Exception {
-        RelativeTimeParser rtParser = new RelativeTimeParser();
-        RelativeTimestamp rtTimestamp = rtParser.parse(modifier);
-        return rtTimestamp.calculate(new Timestamp(unixtime * 1000L)).getEpochSecond();
-    }
-
+    public abstract Instant instant();
 }

--- a/src/main/java/com/teragrep/pth10/ast/time/RelativeTimestamp.java
+++ b/src/main/java/com/teragrep/pth10/ast/time/RelativeTimestamp.java
@@ -64,17 +64,22 @@ public class RelativeTimestamp {
      * @param timestamp A moment in time, usually the current time
      * @return Calculated time as epoch milliseconds
      */
-    public long calculate(Timestamp timestamp) {
+    public Instant calculate(Timestamp timestamp) {
         Instant time = timestamp.toInstant();
 
         // if both are null, "now" option is left. Therefore, returns current time.
-        if (offset == null && snapToTime == null)
+        if (offset == null && snapToTime == null) {
             time = new Timestamp(System.currentTimeMillis()).toInstant();
+        }
 
-        if (offset != null)
+        if (offset != null) {
             time = offset.addOffset(time);
-        if (snapToTime != null)
+        }
+
+        if (snapToTime != null) {
             time = snapToTime.snap(time);
-        return time.getEpochSecond();
+        }
+
+        return time;
     }
 }

--- a/src/main/java/com/teragrep/pth10/ast/time/RoundedUpTimestamp.java
+++ b/src/main/java/com/teragrep/pth10/ast/time/RoundedUpTimestamp.java
@@ -43,29 +43,25 @@
  * Teragrep, the applicable Commercial License may apply to this file if you as
  * a licensee so wish it.
  */
-package com.teragrep.pth10.ast.commands.evalstatement.UDFs;
+package com.teragrep.pth10.ast.time;
 
-import com.teragrep.pth10.ast.time.RelativeTimeParser;
-import com.teragrep.pth10.ast.time.RelativeTimestamp;
-import org.apache.spark.sql.api.java.UDF2;
+import java.time.Instant;
 
-import java.io.Serializable;
-import java.sql.Timestamp;
+public final class RoundedUpTimestamp implements DPLTimestamp {
 
-/**
- * UDF for command relative_time(unixtime, modifier)<br>
- * 
- * @author eemhu
- */
-public class Relative_time implements UDF2<Long, String, Long>, Serializable {
+    private final DPLTimestamp dplTimestamp;
 
-    private static final long serialVersionUID = 1L;
-
-    @Override
-    public Long call(Long unixtime, String modifier) throws Exception {
-        RelativeTimeParser rtParser = new RelativeTimeParser();
-        RelativeTimestamp rtTimestamp = rtParser.parse(modifier);
-        return rtTimestamp.calculate(new Timestamp(unixtime * 1000L)).getEpochSecond();
+    public RoundedUpTimestamp(final DPLTimestamp dplTimestamp) {
+        this.dplTimestamp = dplTimestamp;
     }
 
+    public Instant instant() {
+        Instant origin = dplTimestamp.instant();
+        // If date is for latest timeQualifier and has fractions-of-second, add 1 second to capture events
+        // that are on the same second
+        if (origin.getNano() > 0) {
+            origin = origin.plusSeconds(1);
+        }
+        return origin;
+    }
 }

--- a/src/main/java/com/teragrep/pth10/ast/time/TimeQualifier.java
+++ b/src/main/java/com/teragrep/pth10/ast/time/TimeQualifier.java
@@ -76,7 +76,11 @@ public final class TimeQualifier {
                 throw new IllegalArgumentException("Invalid unix epoch: <[" + value + "]>", e);
             }
         }
-        return new EpochTimestamp(value, timeformat).epoch();
+
+        if (isEndTime()) {
+            return new RoundedUpTimestamp(new InstantTimestamp(value, timeformat)).instant().getEpochSecond();
+        }
+        return new InstantTimestamp(value, timeformat).instant().getEpochSecond();
     }
 
     public Column column() {

--- a/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
+++ b/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
@@ -126,8 +126,12 @@ public class CatalystVisitorTest {
         String q = "((( index =\"cpu\" AND host = \"sc-99-99-14-25\" ) AND sourcetype = \"log:cpu:0\" ) AND ( earliest= \"01/01/1970:02:00:00\"  AND latest= \"01/01/2030:00:00:00\" ))";
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             try {
-                long earliestEpoch = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss").getEpoch("01/01/1970:02:00:00");
-                long latestEpoch = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss").getEpoch("01/01/2030:00:00:00");
+                long earliestEpoch = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss")
+                        .instantOf("01/01/1970:02:00:00")
+                        .getEpochSecond();
+                long latestEpoch = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss")
+                        .instantOf("01/01/2030:00:00:00")
+                        .getEpochSecond();
                 String e = "(((RLIKE(index, (?i)^cpu$) AND RLIKE(host, (?i)^sc-99-99-14-25)) AND RLIKE(sourcetype, (?i)^log:cpu:0)) AND ((_time >= from_unixtime("
                         + earliestEpoch + ", yyyy-MM-dd HH:mm:ss)) AND (_time < from_unixtime(" + latestEpoch
                         + ", yyyy-MM-dd HH:mm:ss))))";
@@ -188,7 +192,7 @@ public class CatalystVisitorTest {
         String q = "index = cinnamon _index_earliest=\"04/16/2020:10:25:40\" | chart count(_raw) as count by _time | where  count > 70";
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             DPLTimeFormat tf = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss");
-            long earliest = Assertions.assertDoesNotThrow(() -> tf.getEpoch("04/16/2020:10:25:40"));
+            long earliest = Assertions.assertDoesNotThrow(() -> tf.instantOf("04/16/2020:10:25:40")).getEpochSecond();
             String e = "(RLIKE(index, (?i)^cinnamon$) AND (_time >= from_unixtime(" + earliest
                     + ", yyyy-MM-dd HH:mm:ss)))";
             DPLParserCatalystContext ctx = this.streamingTestUtil.getCtx();
@@ -225,7 +229,9 @@ public class CatalystVisitorTest {
                     String logicalPart = this.streamingTestUtil.getCtx().getSparkQuery();
                     // check column for archive query i.e. only logical part'
                     DPLTimeFormat tf = new DPLTimeFormat("MM/dd/yyyy:HH:mm:ss");
-                    long indexEarliestEpoch = Assertions.assertDoesNotThrow(() -> tf.getEpoch("04/16/2020:10:25:40"));
+                    long indexEarliestEpoch = Assertions
+                            .assertDoesNotThrow(() -> tf.instantOf("04/16/2020:10:25:40"))
+                            .getEpochSecond();
                     String e = "(RLIKE(index, (?i)^cinnamon$) AND (_time >= from_unixtime(" + indexEarliestEpoch
                             + ", yyyy-MM-dd HH:mm:ss)))";
                     Assertions.assertEquals(e, logicalPart);

--- a/src/test/java/com/teragrep/pth10/DPLTimeFormatTest.java
+++ b/src/test/java/com/teragrep/pth10/DPLTimeFormatTest.java
@@ -72,7 +72,7 @@ public class DPLTimeFormatTest {
         long expectedEpoch = 1702620279;
 
         DPLTimeFormat format = new DPLTimeFormat(dplPattern);
-        long actualEpoch = Assertions.assertDoesNotThrow(() -> format.getEpoch(dplDate));
+        long actualEpoch = Assertions.assertDoesNotThrow(() -> format.instantOf(dplDate).getEpochSecond());
         Assertions.assertEquals(expectedEpoch, actualEpoch);
     }
 }

--- a/src/test/java/com/teragrep/pth10/DefaultTimeFormatTest.java
+++ b/src/test/java/com/teragrep/pth10/DefaultTimeFormatTest.java
@@ -62,6 +62,25 @@ public class DefaultTimeFormatTest {
     }
 
     @Test
+    void ISO8601_fractions_latest_Test() {
+        String time = "2023-12-18T12:40:53.001+03:00"; // different timeformat than default (default would be +02:00)
+        // No longer handled by DefaultTimeFormat, see RoundedUpTimestamp
+        long expected = 1702892453L;
+        long actual = new DefaultTimeFormat().getEpoch(time);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void ISO8601_fractions_earliest_Test() {
+        String time = "2023-12-18T12:40:53.001+03:00"; // different timeformat than default (default would be +02:00)
+        long expected = 1702892453L;
+        long actual = new DefaultTimeFormat().getEpoch(time);
+
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
     void ISO8601_offsetTest() {
         String time = "2023-12-18T12:40:53+03:00"; // different timeformat than default (default would be +02:00)
         long expected = 1702892453L;
@@ -95,5 +114,15 @@ public class DefaultTimeFormatTest {
         long actual = new DefaultTimeFormat().getEpoch(time);
 
         Assertions.assertEquals(expected, actual);
+    }
+
+    @Test
+    void invalidTimeformat() {
+        String time = "12/34/2020:10:25:40";
+        RuntimeException rte = Assertions
+                .assertThrows(RuntimeException.class, () -> new DefaultTimeFormat().getEpoch(time));
+
+        Assertions
+                .assertEquals("TimeQualifier conversion error: <12/34/2020:10:25:40> can't be parsed.", rte.getMessage());
     }
 }

--- a/src/test/java/com/teragrep/pth10/InstantTimestampTest.java
+++ b/src/test/java/com/teragrep/pth10/InstantTimestampTest.java
@@ -1,0 +1,135 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10;
+
+import com.teragrep.pth10.ast.time.InstantTimestamp;
+import com.teragrep.pth10.ast.time.RoundedUpTimestamp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class InstantTimestampTest {
+
+    @Test
+    public void testWithReadableTimeformat() {
+        final String value = "2024-31-10";
+        final String timeformat = "%Y-%d-%m";
+        final Long expected = 1730325600L;
+        InstantTimestamp et = new InstantTimestamp(value, timeformat);
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testWithReadableTimeformatAndIsLatest() {
+        final String value = "2024-31-10";
+        final String timeformat = "%Y-%d-%m";
+        final Long expected = 1730325600L;
+        RoundedUpTimestamp et = new RoundedUpTimestamp(new InstantTimestamp(value, timeformat));
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testWithUnixTimeformat() {
+        final String value = "1730325600";
+        final String timeformat = "%s";
+        final Long expected = 1730325600L;
+        InstantTimestamp et = new InstantTimestamp(value, timeformat);
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testWithUnixTimeformatAndIsLatest() {
+        final String value = "1730325600";
+        final String timeformat = "%s";
+        final Long expected = 1730325600L;
+        RoundedUpTimestamp et = new RoundedUpTimestamp(new InstantTimestamp(value, timeformat));
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testDefaultTimeformat() {
+        final String value = "2024-10-31T10:10:10z";
+        final String timeformat = "";
+        final Long expected = 1730362210L;
+        InstantTimestamp et = new InstantTimestamp(value, timeformat);
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testDefaultTimeformatAndIsLatest() {
+        final String value = "2024-10-31T10:10:10.001";
+        final String timeformat = "";
+        final Long expected = 1730362210L + 1L;
+        RoundedUpTimestamp et = new RoundedUpTimestamp(new InstantTimestamp(value, timeformat));
+        Assertions.assertEquals(expected, et.instant().getEpochSecond());
+    }
+
+    @Test
+    public void testInvalidValue() {
+        final String value = "xyz";
+        final String timeformat = "%Y-%d-%m";
+        RuntimeException e = Assertions
+                .assertThrows(RuntimeException.class, () -> new InstantTimestamp(value, timeformat).instant());
+        Assertions.assertEquals("TimeQualifier conversion error: <" + value + "> can't be parsed.", e.getMessage());
+    }
+
+    @Test
+    public void testEquals() {
+        final String value = "2024-10-31T10:10:10z";
+        final String timeformat = "%Y-%d-%m";
+
+        Assertions.assertEquals(new InstantTimestamp(value, timeformat), new InstantTimestamp(value, timeformat));
+    }
+
+    @Test
+    public void testNotEquals() {
+        final String value = "2024-10-31T10:10:10z";
+        final String value2 = "2024-10-30T10:10:10z";
+        final String timeformat = "%Y-%d-%m";
+
+        Assertions.assertNotEquals(new InstantTimestamp(value, timeformat), new InstantTimestamp(value2, timeformat));
+    }
+
+}

--- a/src/test/java/com/teragrep/pth10/RoundedUpTimestampTest.java
+++ b/src/test/java/com/teragrep/pth10/RoundedUpTimestampTest.java
@@ -45,63 +45,23 @@
  */
 package com.teragrep.pth10;
 
-import com.teragrep.pth10.ast.time.EpochTimestamp;
+import com.teragrep.pth10.ast.time.DPLTimestamp;
+import com.teragrep.pth10.ast.time.InstantTimestamp;
+import com.teragrep.pth10.ast.time.RoundedUpTimestamp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class EpochTimestampTest {
+public final class RoundedUpTimestampTest {
 
     @Test
-    public void testWithReadableTimeformat() {
-        final String value = "2024-31-10";
-        final String timeformat = "%Y-%d-%m";
-        final Long expected = 1730325600L;
-        EpochTimestamp et = new EpochTimestamp(value, timeformat);
-        Assertions.assertEquals(expected, et.epoch());
+    void testWithoutFractions() {
+        DPLTimestamp timestamp = new RoundedUpTimestamp(new InstantTimestamp("2024-01-01T00:00:00+00:00", ""));
+        Assertions.assertEquals(1704067200L, timestamp.instant().getEpochSecond());
     }
 
     @Test
-    public void testWithUnixTimeformat() {
-        final String value = "1730325600";
-        final String timeformat = "%s";
-        final Long expected = 1730325600L;
-        EpochTimestamp et = new EpochTimestamp(value, timeformat);
-        Assertions.assertEquals(expected, et.epoch());
+    void testWithFractions() {
+        DPLTimestamp timestamp = new RoundedUpTimestamp(new InstantTimestamp("2024-01-01T00:00:00.240+00:00", ""));
+        Assertions.assertEquals(1704067200L + 1L, timestamp.instant().getEpochSecond());
     }
-
-    @Test
-    public void testDefaultTimeformat() {
-        final String value = "2024-10-31T10:10:10z";
-        final String timeformat = "";
-        final Long expected = 1730362210L;
-        EpochTimestamp et = new EpochTimestamp(value, timeformat);
-        Assertions.assertEquals(expected, et.epoch());
-    }
-
-    @Test
-    public void testInvalidValue() {
-        final String value = "xyz";
-        final String timeformat = "%Y-%d-%m";
-        RuntimeException e = Assertions
-                .assertThrows(RuntimeException.class, () -> new EpochTimestamp(value, timeformat).epoch());
-        Assertions.assertEquals("TimeQualifier conversion error: <" + value + "> can't be parsed.", e.getMessage());
-    }
-
-    @Test
-    public void testEquals() {
-        final String value = "2024-10-31T10:10:10z";
-        final String timeformat = "%Y-%d-%m";
-
-        Assertions.assertEquals(new EpochTimestamp(value, timeformat), new EpochTimestamp(value, timeformat));
-    }
-
-    @Test
-    public void testNotEquals() {
-        final String value = "2024-10-31T10:10:10z";
-        final String value2 = "2024-10-30T10:10:10z";
-        final String timeformat = "%Y-%d-%m";
-
-        Assertions.assertNotEquals(new EpochTimestamp(value, timeformat), new EpochTimestamp(value2, timeformat));
-    }
-
 }

--- a/src/test/java/com/teragrep/pth10/TimeQualifierTest.java
+++ b/src/test/java/com/teragrep/pth10/TimeQualifierTest.java
@@ -76,6 +76,70 @@ public class TimeQualifierTest {
     }
 
     @Test
+    public void testEarliestWithFractions() {
+        final String value = "2024-01-01T10:00:00.001Z";
+        final int type = DPLLexer.EARLIEST;
+        final Document doc = Assertions
+                .assertDoesNotThrow(() -> DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument());
+        TimeQualifier tq = new TimeQualifier(value, "", type, doc);
+        Column expected = new Column("`_time`").geq(functions.from_unixtime(functions.lit(1704103200L)));
+        Element el = doc.createElement("earliest");
+        el.setAttribute("operation", "GE");
+        el.setAttribute("value", Long.toString(1704103200L));
+
+        Assertions.assertEquals(expected, tq.column());
+        Assertions.assertEquals(el.toString(), tq.xmlElement().toString());
+    }
+
+    @Test
+    public void testEarliestWithoutFractions() {
+        final String value = "2024-01-01T10:00:00.000Z";
+        final int type = DPLLexer.EARLIEST;
+        final Document doc = Assertions
+                .assertDoesNotThrow(() -> DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument());
+        TimeQualifier tq = new TimeQualifier(value, "", type, doc);
+        Column expected = new Column("`_time`").geq(functions.from_unixtime(functions.lit(1704103200L)));
+        Element el = doc.createElement("earliest");
+        el.setAttribute("operation", "GE");
+        el.setAttribute("value", Long.toString(1704103200L));
+
+        Assertions.assertEquals(expected, tq.column());
+        Assertions.assertEquals(el.toString(), tq.xmlElement().toString());
+    }
+
+    @Test
+    public void testLatestWithFractions() {
+        final String value = "2024-01-01T10:00:00.001Z";
+        final int type = DPLLexer.LATEST;
+        final Document doc = Assertions
+                .assertDoesNotThrow(() -> DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument());
+        TimeQualifier tq = new TimeQualifier(value, "", type, doc);
+        Column expected = new Column("`_time`").lt(functions.from_unixtime(functions.lit(1704103200L + 1L)));
+        Element el = doc.createElement("latest");
+        el.setAttribute("operation", "LE");
+        el.setAttribute("value", Long.toString(1704103200L + 1L));
+
+        Assertions.assertEquals(expected, tq.column());
+        Assertions.assertEquals(el.toString(), tq.xmlElement().toString());
+    }
+
+    @Test
+    public void testLatestWithoutFractions() {
+        final String value = "2024-01-01T10:00:00.000Z";
+        final int type = DPLLexer.LATEST;
+        final Document doc = Assertions
+                .assertDoesNotThrow(() -> DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument());
+        TimeQualifier tq = new TimeQualifier(value, "", type, doc);
+        Column expected = new Column("`_time`").lt(functions.from_unixtime(functions.lit(1704103200L)));
+        Element el = doc.createElement("latest");
+        el.setAttribute("operation", "LE");
+        el.setAttribute("value", Long.toString(1704103200L));
+
+        Assertions.assertEquals(expected, tq.column());
+        Assertions.assertEquals(el.toString(), tq.xmlElement().toString());
+    }
+
+    @Test
     public void testLatest() {
         final String value = "2024-31-10";
         final String timeformat = "%Y-%d-%m";

--- a/src/test/java/com/teragrep/pth10/relativeTimeTest.java
+++ b/src/test/java/com/teragrep/pth10/relativeTimeTest.java
@@ -231,7 +231,7 @@ public class relativeTimeTest {
         Instant exp = t1.plus(-1, ChronoUnit.HOURS);
         LocalDateTime etime = LocalDateTime.ofInstant(exp, ZoneOffset.UTC);
         RelativeTimestamp rtTimestamp = rtParser.parse("-1h");
-        long rtEpoch = rtTimestamp.calculate(timestamp);
+        long rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(etime.getHour(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.UTC).getHour());
 
@@ -239,7 +239,7 @@ public class relativeTimeTest {
         exp = t1.plus(-3, ChronoUnit.MINUTES);
         etime = LocalDateTime.ofInstant(exp, ZoneOffset.UTC);
         rtTimestamp = rtParser.parse("-3m");
-        rtEpoch = rtTimestamp.calculate(timestamp);
+        rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(etime.getMinute(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.UTC).getMinute());
         // Using localDateTime-method
@@ -247,14 +247,14 @@ public class relativeTimeTest {
         LocalDateTime dt = timestamp.toLocalDateTime();
         LocalDateTime et = dt.minusWeeks(1);
         rtTimestamp = rtParser.parse("-1w");
-        rtEpoch = rtTimestamp.calculate(timestamp);
+        rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(et.getDayOfWeek(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.UTC).getDayOfWeek());
         // -3 month
         dt = timestamp.toLocalDateTime();
         et = dt.minusMonths(3);
         rtTimestamp = rtParser.parse("-3mon");
-        rtEpoch = rtTimestamp.calculate(timestamp);
+        rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(et.getMonth(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.UTC).getMonth());
 
@@ -262,7 +262,7 @@ public class relativeTimeTest {
         dt = timestamp.toLocalDateTime();
         et = dt.minusYears(7);
         rtTimestamp = rtParser.parse("-7y");
-        rtEpoch = rtTimestamp.calculate(timestamp);
+        rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(et.getYear(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.UTC).getYear());
     }
@@ -286,7 +286,7 @@ public class relativeTimeTest {
         et = et.minusSeconds(40); // Thu Feb 3, 2022 00:00 UTC
 
         RelativeTimestamp rtTimestamp = rtParser.parse("@d");
-        long rtEpoch = rtTimestamp.calculate(timestamp);
+        long rtEpoch = rtTimestamp.calculate(timestamp).getEpochSecond();
         Assertions
                 .assertEquals(et.getDayOfWeek(), LocalDateTime.ofInstant(Instant.ofEpochSecond(rtEpoch), ZoneOffset.systemDefault()).getDayOfWeek());
     }

--- a/src/test/resources/earliestLatestTest_data.jsonl
+++ b/src/test/resources/earliestLatestTest_data.jsonl
@@ -1,10 +1,10 @@
-{"_time": "2013-07-15 10:01:50", "id": 1, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.0", "partition": "0", "offset": 1}
-{"_time": "2013-08-14 20:30:53", "id": 2, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.1.1.1", "partition": "0", "offset": 2}
-{"_time": "2013-09-14 06:59:56", "id": 3, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.2.2.2", "partition": "0", "offset": 3}
-{"_time": "2013-10-14 17:28:59", "id": 4, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.3.3.3", "partition": "0", "offset": 4}
-{"_time": "2013-11-14 03:58:02", "id": 5, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.4.4.4", "partition": "0", "offset": 5}
-{"_time": "2013-12-14 14:27:05", "id": 6, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.5.5.5", "partition": "0", "offset": 6}
-{"_time": "2014-01-14 00:56:08", "id": 7, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.6.6.6", "partition": "0", "offset": 7}
-{"_time": "2014-02-13 11:25:11", "id": 8, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.7.7.7", "partition": "0", "offset": 8}
-{"_time": "2014-03-15 21:54:14", "id": 9, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.8.8.8", "partition": "0", "offset": 9}
-{"_time": "2014-04-15 08:23:17", "id": 10, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.9.9.9", "partition": "0", "offset": 10}
+{"_time": "2013-07-15T10:01:50+02:00", "id": 1, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.0", "partition": "0", "offset": 1}
+{"_time": "2013-08-14T20:30:53+02:00", "id": 2, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.1.1.1", "partition": "0", "offset": 2}
+{"_time": "2013-09-14T06:59:56+02:00", "id": 3, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.2.2.2", "partition": "0", "offset": 3}
+{"_time": "2013-10-14T17:28:59+02:00", "id": 4, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.3.3.3", "partition": "0", "offset": 4}
+{"_time": "2013-11-14T03:58:02+02:00", "id": 5, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.4.4.4", "partition": "0", "offset": 5}
+{"_time": "2013-12-14T14:27:05+02:00", "id": 6, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.5.5.5", "partition": "0", "offset": 6}
+{"_time": "2014-01-14T00:56:08+02:00", "id": 7, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.6.6.6", "partition": "0", "offset": 7}
+{"_time": "2014-02-13T11:25:11+02:00", "id": 8, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.7.7.7", "partition": "0", "offset": 8}
+{"_time": "2014-03-15T21:54:14+02:00", "id": 9, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.8.8.8", "partition": "0", "offset": 9}
+{"_time": "2014-04-15T08:23:17+02:00", "id": 10, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.9.9.9", "partition": "0", "offset": 10}

--- a/src/test/resources/earliestLatestTest_epoch_data.jsonl
+++ b/src/test/resources/earliestLatestTest_epoch_data.jsonl
@@ -1,10 +1,10 @@
-{"_time": "1970-01-01 00:00:00", "id": 1, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 1}
-{"_time": "1980-01-01 00:00:00", "id": 2, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 2}
-{"_time": "1990-09-14 06:59:56", "id": 3, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 3}
-{"_time": "2000-10-14 17:28:59", "id": 4, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 4}
-{"_time": "2010-11-14 03:58:02", "id": 5, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 5}
-{"_time": "2020-12-14 14:27:05", "id": 6, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 6}
-{"_time": "2030-01-14 00:56:08", "id": 7, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 7}
-{"_time": "2040-02-13 11:25:11", "id": 8, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 8}
-{"_time": "2050-03-15 21:54:14", "id": 9, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 9}
-{"_time": "2060-04-15 08:23:17", "id": 10, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 10}
+{"_time": "1970-01-01T00:00:00+02:00", "id": 1, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 1}
+{"_time": "1980-01-01T00:00:00+02:00", "id": 2, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 2}
+{"_time": "1990-09-14T06:59:56+02:00", "id": 3, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 3}
+{"_time": "2000-10-14T17:28:59+02:00", "id": 4, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 4}
+{"_time": "2010-11-14T03:58:02+02:00", "id": 5, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 5}
+{"_time": "2020-12-14T14:27:05+02:00", "id": 6, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 6}
+{"_time": "2030-01-14T00:56:08+02:00", "id": 7, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 7}
+{"_time": "2040-02-13T11:25:11+02:00", "id": 8, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 8}
+{"_time": "2050-03-15T21:54:14+02:00", "id": 9, "_raw": "data data", "index": "strawberry", "sourcetype": "stream1", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 9}
+{"_time": "2060-04-15T08:23:17+02:00", "id": 10, "_raw": "data data", "index": "seagull", "sourcetype": "stream2", "host": "webserver.example.com", "source": "127.0.0.1", "partition": "0", "offset": 10}


### PR DESCRIPTION
Fixes issue:
* #435 

Changes:
* Rounds up to the nearest second if fractions-of-second are used in the latest timeQualifier. Earliest timeQualifier ignores subseconds / rounds them down.
* Added timezones to test data.

