### PR TITLE
remove duplicate dependency nl.jqno.equalsverifier from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,12 +255,6 @@
       <artifactId>slf4j-api</artifactId>
       <version>2.0.16</version>
     </dependency>
-    <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <version>3.17.4</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <directory>${project.basedir}/target</directory>


### PR DESCRIPTION
Dependency already defined on line 124  in pom.xml