### PR TITLE
issue_484: Null pointer passed  to DPLParserCatalystVisitor

### DIFF
--- a/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
@@ -144,4 +144,8 @@ public abstract class Node {
             return this.toString();
         }
     }
+
+    public boolean isStub() {
+        return false;
+    }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
@@ -145,7 +145,7 @@ public abstract class Node {
         }
     }
 
-    public boolean isStub() {
+    public boolean isNull() {
         return false;
     }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/Node.java
@@ -145,7 +145,7 @@ public abstract class Node {
         }
     }
 
-    public boolean isNull() {
+    public boolean isStub() {
         return false;
     }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
@@ -58,4 +58,9 @@ public class NullNode extends Node {
     public String toString() {
         return "";
     }
+
+    @Override
+    public boolean isStub() {
+        return true;
+    }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
@@ -60,7 +60,7 @@ public class NullNode extends Node {
     }
 
     @Override
-    public boolean isStub() {
+    public boolean isNull() {
         return true;
     }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
+++ b/src/main/java/com/teragrep/pth_10/ast/bo/NullNode.java
@@ -55,12 +55,32 @@ public class NullNode extends Node {
     }
 
     @Override
-    public String toString() {
-        return "";
+    public Token.Type getNodeType() {
+        throw new UnsupportedOperationException("NullNode does not support getNodeType()");
     }
 
     @Override
-    public boolean isNull() {
+    public String toTree() {
+        throw new UnsupportedOperationException("NullNode does not support toTree()");
+    }
+
+    @Override
+    public void addChild(Node child) {
+        throw new UnsupportedOperationException("NullNode does not support addChild()");
+    }
+
+    @Override
+    public String toString() {
+        return "NullNode";
+    }
+
+    @Override
+    public String toXMLTree() {
+        throw new UnsupportedOperationException("NullNode does not support toXMLTree()");
+    }
+
+    @Override
+    public boolean isStub() {
         return true;
     }
 }

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -143,7 +143,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
     @Override
     public Node visitSearchTransformationRoot(DPLParser.SearchTransformationRootContext ctx) {
         final Node rv;
-        if (LOGGER.isInfoEnabled()){
+        if (LOGGER.isInfoEnabled()) {
             LOGGER
                     .info(
                             "[SearchTransformationRoot CAT] Visiting: <{}> with <{}> children", ctx.getText(),
@@ -156,7 +156,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
             final Node singleNode = visit(ctx.getChild(0));
             if (singleNode.isStub()) {
                 LOGGER.info("Child node was a NullNode");
-                rv = new NullNode();
+                rv = singleNode;
             }
             else {
                 rv = singleNode;
@@ -207,7 +207,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         if (rv instanceof ColumnNode) {
             final ColumnNode columnNode = (ColumnNode) rv;
             if (columnNode.getColumn() != null) {
-                if (LOGGER.isInfoEnabled()){
+                if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Spark column: <{}>", columnNode.getColumn().toString());
                 }
                 this.catCtx.setSparkQuery(columnNode.getColumn().toString());

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -625,28 +625,32 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
     @Override
     public Node visitSubsearchStatement(DPLParser.SubsearchStatementContext ctx) {
         if (LOGGER.isInfoEnabled()) {
-        LOGGER.info("queryId <{}> visitSubsearchStatement with brackets: <{}>", catCtx.getQueryName(), ctx.getText());
+            LOGGER
+                    .info(
+                            "queryId <{}> visitSubsearchStatement with brackets: <{}>", catCtx.getQueryName(),
+                            ctx.getText()
+                    );
         }
         if (catCtx == null) {
             throw new IllegalStateException("DPL parser catalyst context is missing");
         }
         if (LOGGER.isInfoEnabled()) {
-        LOGGER.info("queryId <{}> Cloning main visitor to subsearch", catCtx.getQueryName());
+            LOGGER.info("queryId <{}> Cloning main visitor to subsearch", catCtx.getQueryName());
         }
         final DPLParserCatalystContext subCtx = catCtx.clone();
         if (LOGGER.isInfoEnabled()) {
-        LOGGER.info("queryId <{}> (Catalyst) subVisitor init with subCtx= <{}>", catCtx.getQueryName(), subCtx);
+            LOGGER.info("queryId <{}> (Catalyst) subVisitor init with subCtx= <{}>", catCtx.getQueryName(), subCtx);
         }
         final DPLParserCatalystVisitor subVisitor = new DPLParserCatalystVisitor(subCtx);
 
         // Pass actual subsearch branch
         final StepNode subSearchNode = (StepNode) subVisitor.visit(ctx);
         if (LOGGER.isInfoEnabled()) {
-        LOGGER
-                .info(
-                        "queryId <{}> SubSearchTransformation (Catalyst) Result: class=<{}>", catCtx.getQueryName(),
-                        subSearchNode.getClass().getName()
-                );
+            LOGGER
+                    .info(
+                            "queryId <{}> SubSearchTransformation (Catalyst) Result: class=<{}>", catCtx.getQueryName(),
+                            subSearchNode.getClass().getName()
+                    );
         }
 
         final SubsearchStep subsearchStep = (SubsearchStep) subSearchNode.get();

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -123,7 +123,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
     public AbstractStep visitLogicalStatementCatalyst(DPLParser.SearchTransformationRootContext ctx) {
         if (ctx != null) {
             final Node ret = visitSearchTransformationRoot(ctx);
-            if (!ret.isNull()) {
+            if (!ret.isStub()) {
                 final Column filterColumn = ((ColumnNode) visitSearchTransformationRoot(ctx)).getColumn();
                 return new LogicalCatalystStep(filterColumn);
             }
@@ -154,7 +154,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         if (ctx.getChildCount() == 1) {
             // just a single directoryStatement -or- logicalStatement
             final Node singleNode = visit(ctx.getChild(0));
-            if (singleNode.isNull()) {
+            if (singleNode.isStub()) {
                 LOGGER.info("Child node was a NullNode");
                 rv = singleNode;
             }
@@ -170,11 +170,11 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
                 // case: directoryStmt OR logicalStmt
                 final Node directoryNode = visit(ctx.directoryStatement());
                 final Node logicalNode = visit(ctx.logicalStatement(0));
-                if (directoryNode.isNull()) {
+                if (directoryNode.isStub()) {
                     LOGGER.info("Directory statement node was a NullNode");
                     rv = directoryNode;
                 }
-                else if (logicalNode.isNull()) {
+                else if (logicalNode.isStub()) {
                     LOGGER.info("Logical statement node was a NullNode");
                     rv = logicalNode;
                 }
@@ -187,7 +187,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
             else {
                 // case: (logicalStmt AND?)*? directoryStmt (AND? logicalStmt)*?
                 final Node finalNode = visit(ctx.directoryStatement());
-                if (finalNode.isNull()) {
+                if (finalNode.isStub()) {
                     LOGGER.info("Directory statement node was a NullNode");
                     rv = finalNode;
                 }

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -598,24 +598,32 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
 
     @Override
     public Node visitSubsearchStatement(DPLParser.SubsearchStatementContext ctx) {
+        if (LOGGER.isInfoEnabled()) {
         LOGGER.info("queryId <{}> visitSubsearchStatement with brackets: <{}>", catCtx.getQueryName(), ctx.getText());
+        }
         if (catCtx == null) {
             throw new IllegalStateException("DPL parser catalyst context is missing");
         }
+        if (LOGGER.isInfoEnabled()) {
         LOGGER.info("queryId <{}> Cloning main visitor to subsearch", catCtx.getQueryName());
+        }
         final DPLParserCatalystContext subCtx = catCtx.clone();
+        if (LOGGER.isInfoEnabled()) {
         LOGGER.info("queryId <{}> (Catalyst) subVisitor init with subCtx= <{}>", catCtx.getQueryName(), subCtx);
-        DPLParserCatalystVisitor subVisitor = new DPLParserCatalystVisitor(subCtx);
+        }
+        final DPLParserCatalystVisitor subVisitor = new DPLParserCatalystVisitor(subCtx);
 
         // Pass actual subsearch branch
-        StepNode subSearchNode = (StepNode) subVisitor.visit(ctx);
+        final StepNode subSearchNode = (StepNode) subVisitor.visit(ctx);
+        if (LOGGER.isInfoEnabled()) {
         LOGGER
                 .info(
                         "queryId <{}> SubSearchTransformation (Catalyst) Result: class=<{}>", catCtx.getQueryName(),
                         subSearchNode.getClass().getName()
                 );
+        }
 
-        SubsearchStep subsearchStep = (SubsearchStep) subSearchNode.get();
+        final SubsearchStep subsearchStep = (SubsearchStep) subSearchNode.get();
         // These have to be set here and not in subVisitor to be the same as in other Steps
         subsearchStep.setListener(this.catCtx.getInternalStreamingQueryListener());
         subsearchStep.setHdfsPath(this.catVisitor.getHdfsPath());
@@ -623,7 +631,6 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         // add subsearch to stepList
         this.catVisitor.getStepList().add(subsearchStep);
 
-        //Node rv = new CatalystNode(subVisitor.getStack().pop());
         return new NullNode();
     }
 

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -157,7 +157,8 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
             if (singleNode.isStub()) {
                 LOGGER.info("Child node was a NullNode");
                 rv = new NullNode();
-            } else {
+            }
+            else {
                 rv = singleNode;
             }
         }

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -123,7 +123,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
     public AbstractStep visitLogicalStatementCatalyst(DPLParser.SearchTransformationRootContext ctx) {
         if (ctx != null) {
             final Node ret = visitSearchTransformationRoot(ctx);
-            if (!ret.isStub()) {
+            if (!ret.isNull()) {
                 final Column filterColumn = ((ColumnNode) visitSearchTransformationRoot(ctx)).getColumn();
                 return new LogicalCatalystStep(filterColumn);
             }
@@ -154,7 +154,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         if (ctx.getChildCount() == 1) {
             // just a single directoryStatement -or- logicalStatement
             final Node singleNode = visit(ctx.getChild(0));
-            if (singleNode.isStub()) {
+            if (singleNode.isNull()) {
                 LOGGER.info("Child node was a NullNode");
                 rv = singleNode;
             }
@@ -170,11 +170,11 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
                 // case: directoryStmt OR logicalStmt
                 final Node directoryNode = visit(ctx.directoryStatement());
                 final Node logicalNode = visit(ctx.logicalStatement(0));
-                if (directoryNode.isStub()) {
+                if (directoryNode.isNull()) {
                     LOGGER.info("Directory statement node was a NullNode");
                     rv = directoryNode;
                 }
-                else if (logicalNode.isStub()) {
+                else if (logicalNode.isNull()) {
                     LOGGER.info("Logical statement node was a NullNode");
                     rv = logicalNode;
                 }
@@ -187,7 +187,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
             else {
                 // case: (logicalStmt AND?)*? directoryStmt (AND? logicalStmt)*?
                 final Node finalNode = visit(ctx.directoryStatement());
-                if (finalNode.isStub()) {
+                if (finalNode.isNull()) {
                     LOGGER.info("Directory statement node was a NullNode");
                     rv = finalNode;
                 }

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -179,9 +179,10 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
             final Node singleNode = visit(ctx.getChild(0));
             if (singleNode instanceof NullNode) {
                 LOGGER.info("Child node was a NullNode");
-                return singleNode;
+                rv = new NullNode();
+            } else {
+                rv = singleNode;
             }
-            rv = singleNode;
         }
         else {
             final ParseTree secondChild = ctx.getChild(1);

--- a/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/logicalstatement/LogicalStatementCatalyst.java
@@ -600,7 +600,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
     public Node visitSubsearchStatement(DPLParser.SubsearchStatementContext ctx) {
         LOGGER.info("queryId <{}> visitSubsearchStatement with brackets: <{}>", catCtx.getQueryName(), ctx.getText());
         if (catCtx == null) {
-            throw new IllegalStateException("Catalyst context is null!");
+            throw new IllegalStateException("DPL parser catalyst context is missing");
         }
         LOGGER.info("queryId <{}> Cloning main visitor to subsearch", catCtx.getQueryName());
         final DPLParserCatalystContext subCtx = catCtx.clone();
@@ -624,7 +624,7 @@ public class LogicalStatementCatalyst extends DPLParserBaseVisitor<Node> {
         this.catVisitor.getStepList().add(subsearchStep);
 
         //Node rv = new CatalystNode(subVisitor.getStack().pop());
-        return null;
+        return new NullNode();
     }
 
     /*@Override


### PR DESCRIPTION
- throw an exception when DPLParserCatalystContext is missing  instead of passing a Null pointer to DPLParserCatalystVisitor
- return NullNode instead of null