### PR TITLE
issue_515: Fix calling a method on null object in SearchTransformation

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/SearchTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/SearchTransformation.java
@@ -51,6 +51,7 @@ import com.teragrep.pth10.ast.commands.logicalstatement.LogicalStatementCatalyst
 import com.teragrep.pth10.steps.search.SearchStep;
 import com.teragrep.pth_03.antlr.DPLParser;
 import com.teragrep.pth_03.antlr.DPLParserBaseVisitor;
+import org.apache.spark.sql.functions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,11 +85,16 @@ public class SearchTransformation extends DPLParserBaseVisitor<Node> {
         if (searchRootCtx != null) {
             // isSearchCommand=true is used to skip generating archiveQuery as 'search' is used to filter existing dataset
             // rather than getting a new one and filtering it
-            LogicalStatementCatalyst logiStat = new LogicalStatementCatalyst(this.catCtx);
+            final LogicalStatementCatalyst logiStat = new LogicalStatementCatalyst(this.catCtx);
             LOGGER.info("SearchTransformationRoot - skipping xml generation");
-            ColumnNode filter = (ColumnNode) logiStat.visitSearchTransformationRoot(searchRootCtx);
-            searchStep.setFilteringColumn(filter.getColumn());
-
+            final ColumnNode filter = (ColumnNode) logiStat.visitSearchTransformationRoot(searchRootCtx);
+            if (filter.getColumn() != null) {
+                searchStep.setFilteringColumn(filter.getColumn());
+            }
+            else {
+                final ColumnNode filterColumn = new ColumnNode(functions.lit(false));
+                searchStep.setFilteringColumn(filterColumn.getColumn());
+            }
         }
         else {
             throw new IllegalStateException(

--- a/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/SearchTransformation.java
+++ b/src/main/java/com/teragrep/pth10/ast/commands/transformstatement/SearchTransformation.java
@@ -51,7 +51,6 @@ import com.teragrep.pth10.ast.commands.logicalstatement.LogicalStatementCatalyst
 import com.teragrep.pth10.steps.search.SearchStep;
 import com.teragrep.pth_03.antlr.DPLParser;
 import com.teragrep.pth_03.antlr.DPLParserBaseVisitor;
-import org.apache.spark.sql.functions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,8 +91,9 @@ public class SearchTransformation extends DPLParserBaseVisitor<Node> {
                 searchStep.setFilteringColumn(filter.getColumn());
             }
             else {
-                final ColumnNode filterColumn = new ColumnNode(functions.lit(false));
-                searchStep.setFilteringColumn(filterColumn.getColumn());
+                throw new IllegalStateException(
+                        "search command expected filtering value(s) but found: <" + filter.getColumn() + ">."
+                );
             }
         }
         else {

--- a/src/test/java/com/teragrep/pth10/statsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/statsTransformationTest.java
@@ -883,4 +883,25 @@ public class statsTransformationTest {
                     Assertions.assertEquals(Collections.singletonList("1286709610"), destAsList);
                 });
     }
+
+    @Test
+    @DisabledIfSystemProperty(
+            named = "skipSparkTest",
+            matches = "true"
+    )
+    public void testQueryWithoutDatasource() {
+        String query = "| stats count";
+
+        this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
+            List<String> listOfRaw = res
+                    .select("count")
+                    .collectAsList()
+                    .stream()
+                    .map(r -> r.getAs(0).toString())
+                    .collect(Collectors.toList());
+
+            Assertions.assertEquals(1, res.count()); // 1 row of data
+            Assertions.assertEquals("0", listOfRaw.get(0));
+        });
+    }
 }


### PR DESCRIPTION
- Fix calling a method on null object.
- Added unit test for query without dataset