### PR TITLE
Issue_458: Improved error message for incorrect timestamp format

### DIFF
--- a/src/main/java/com/teragrep/pth10/ast/DefaultTimeFormat.java
+++ b/src/main/java/com/teragrep/pth10/ast/DefaultTimeFormat.java
@@ -75,30 +75,35 @@ public class DefaultTimeFormat {
     public Date parse(String time) {
         // Try parsing all the three default timeformats
         Date date;
-
+        final String defaultFormat = "MM/dd/yyyy:HH:mm:ss";
+        final String withTimezone = "yyyy-MM-dd'T'HH:mm:ssXXX";
+        final String withoutTimezone = "yyyy-MM-dd'T'HH:mm:ss";
         int attempt = 0;
         while (true) {
             try {
                 if (attempt == 0) {
                     // Use default format (MM/dd/yyyy:HH:mm:ss)
                     // Use system default timezone
-                    date = this.parseDate(time, "MM/dd/yyyy:HH:mm:ss");
+                    date = this.parseDate(time, defaultFormat);
                 }
                 else if (attempt == 1) {
                     // On first fail, try ISO 8601 with timezone offset, e.g. '2011-12-03T10:15:30+01:00'
-                    date = this.parseDate(time, "yyyy-MM-dd'T'HH:mm:ssXXX");
+                    date = this.parseDate(time, withTimezone);
                 }
                 else {
                     // On second fail, try ISO 8601 without offset, e.g. '2011-12-03T10:15:30'
                     // Use system default timezone
-                    date = this.parseDate(time, "yyyy-MM-dd'T'HH:mm:ss");
+                    date = this.parseDate(time, withoutTimezone);
                 }
                 break;
 
             }
-            catch (ParseException e) {
+            catch (final ParseException e) {
                 if (attempt > 1) {
-                    throw new RuntimeException("TimeQualifier conversion error: <" + time + "> can't be parsed.");
+                    throw new RuntimeException(
+                            "Check that the timestamp or the relative time value is in the correct format (Supported timestamp formats <"
+                                    + defaultFormat + ">, <" + withoutTimezone + ">, <" + withTimezone + ">)"
+                    );
                 }
             }
             finally {

--- a/src/main/java/com/teragrep/pth10/ast/time/EpochTimestamp.java
+++ b/src/main/java/com/teragrep/pth10/ast/time/EpochTimestamp.java
@@ -49,6 +49,8 @@ import com.teragrep.pth10.ast.DPLTimeFormat;
 import com.teragrep.pth10.ast.DefaultTimeFormat;
 import com.teragrep.pth10.ast.TextString;
 import com.teragrep.pth10.ast.UnquotedText;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
 import java.text.ParseException;
@@ -56,6 +58,7 @@ import java.util.Objects;
 
 public final class EpochTimestamp {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EpochTimestamp.class);
     private final String value;
     private final String timeformat;
 
@@ -71,7 +74,8 @@ public final class EpochTimestamp {
             rv = relativeTimestamp.calculate(new Timestamp(System.currentTimeMillis()));
         }
         catch (NumberFormatException ne) {
-            rv = epochFromString(value, timeformat);
+            LOGGER.debug("Could not parse relative timestamp, trying default formats");
+            rv = epochFromString(value, timeformat, ne);
         }
 
         return rv;
@@ -79,11 +83,19 @@ public final class EpochTimestamp {
 
     // Uses defaultTimeFormat if timeformat is null and DPLTimeFormat if timeformat isn't null (which means that the
     // timeformat= option was used).
-    private long epochFromString(final String value, final String timeFormatString) {
+    private long epochFromString(final String value, final String timeFormatString, final NumberFormatException cause) {
         final String unquotedValue = new UnquotedText(new TextString(value)).read(); // erase the possible outer quotes
         final long timevalue;
         if (timeFormatString == null || timeFormatString.isEmpty()) {
-            timevalue = new DefaultTimeFormat().getEpoch(unquotedValue);
+            try {
+                timevalue = new DefaultTimeFormat().getEpoch(unquotedValue);
+            }
+            catch (final RuntimeException ex) {
+                throw new RuntimeException(
+                        "Error parsing <" + unquotedValue + ">. " + ex.getMessage() + ". " + cause.getMessage() + ".",
+                        cause
+                );
+            }
         }
         else {
             // TODO: should be included in DPLTimeFormat

--- a/src/test/java/com/teragrep/pth10/EarliestLatestTest.java
+++ b/src/test/java/com/teragrep/pth10/EarliestLatestTest.java
@@ -343,7 +343,10 @@ public class EarliestLatestTest {
                 .performThrowingDPLTest(RuntimeException.class, query, this.testFile, res -> {
                 });
         Assertions
-                .assertEquals("TimeQualifier conversion error: <31/31/2014:00:00:00> can't be parsed.", sqe.getMessage());
+                .assertEquals(
+                        "Error parsing <31/31/2014:00:00:00>. Check that the timestamp or the relative time value is in the correct format (Supported timestamp formats <MM/dd/yyyy:HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ssXXX>). Unknown relative time modifier string [31/31/2014:00:00:00].",
+                        sqe.getMessage()
+                );
     }
 
     @Test

--- a/src/test/java/com/teragrep/pth10/relativeTimeTest.java
+++ b/src/test/java/com/teragrep/pth10/relativeTimeTest.java
@@ -336,7 +336,7 @@ public class relativeTimeTest {
     )
     public void parseTimestampLatestRelativeTestWithoutSign() {
         String q = "index=cinnamon latest=3h ";
-        String expected = "TimeQualifier conversion error: <3h> can't be parsed.";
+        String expected = "Error parsing <3h>. Check that the timestamp or the relative time value is in the correct format (Supported timestamp formats <MM/dd/yyyy:HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ssXXX>). Unknown relative time modifier string [3h].";
 
         RuntimeException exception = this.streamingTestUtil
                 .performThrowingDPLTest(RuntimeException.class, q, this.testFile, res -> {
@@ -422,7 +422,7 @@ public class relativeTimeTest {
             String expectedLatestString = String.valueOf(expectedLatest).substring(0, 7); // don't check last 2 numbers as the query takes some time and the "now" is different
             String regex = "^.*_time >= from_unixtime\\(" + expectedEarliest + ".*_time < from_unixtime\\("
                     + expectedLatestString + ".*$";
-            ;
+
             String result = this.streamingTestUtil.getCtx().getSparkQuery();
             Assertions.assertTrue(result.matches(regex));
         });
@@ -437,7 +437,7 @@ public class relativeTimeTest {
     public void parseTimestampRelativeInvalidSnapToTimeUnitTest() {
         // pth10 ticket #66 query: 'index=... sourcetype=... earliest=@-5h latest=@-3h'
         String query = "index=cinnamon earliest=\"@-5h\" latest=\"@-3h\"";
-        String expected = "TimeQualifier conversion error: <@-5h> can't be parsed.";
+        String expected = "Error parsing <@-5h>. Check that the timestamp or the relative time value is in the correct format (Supported timestamp formats <MM/dd/yyyy:HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ss>, <yyyy-MM-dd'T'HH:mm:ssXXX>). Unknown relative time modifier string [@-5h].";
 
         RuntimeException exception = this.streamingTestUtil
                 .performThrowingDPLTest(RuntimeException.class, query, this.testFile, res -> {


### PR DESCRIPTION
 - Improved error message for incorrect timestamp format
- Added a debug log message for unparseable relative timestamp 