### PR TITLE
added exception if leftTree is null

### DIFF
--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -107,14 +107,6 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
         final ParseTree leftTree = ctx.getChild(0);
         final ParseTree rightTree = ctx.getChild(2);
 
-        // Logging
-        if (rightTree != null) {
-            LOGGER.info("queryId <{}> -> Right tree: text=<{}>", catCtx.getQueryName(), rightTree.getText());
-        }
-        else {
-            LOGGER.info("queryId <{}> -> Right tree NULL", catCtx.getQueryName());
-        }
-
         if (leftTree != null) {
             LOGGER.info("-> Left tree: text=<{}>", leftTree.getText());
             // Visit command transformations
@@ -137,6 +129,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
                 }
                 // Add right branch
                 if (rightTree != null) {
+                    LOGGER.info("queryId <{}> -> Right tree: text=<{}>", catCtx.getQueryName(), rightTree.getText());
                     final Node right = visit(rightTree);
                     if (right != null) {
                         LOGGER.debug("Right side was not null: <{}>", right);
@@ -147,6 +140,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
                     }
                 }
                 else { // EOF, return only left
+                    LOGGER.info("queryId <{}> -> Right tree NULL", catCtx.getQueryName());
                     LOGGER.debug("transformStatement <EOF> return only left transformation");
                 }
 

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -155,7 +155,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
             }
         }
         else {
-            LOGGER.error("-> Left tree is NULL");
+            LOGGER.error("queryId <{}> -> Left tree is NULL", catCtx.getQueryName());
             throw new IllegalArgumentException(
                     "The provided transformation command '" + ctx.getText() + "' is not yet implemented."
             );

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -121,11 +121,10 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
                     ((StepListNode) left).asList().forEach(step -> this.catVisitor.getStepList().add(step));
                 }
                 else {
-                    LOGGER
-                            .error(
-                                    "queryId <{}> visit of leftTree did not return Step(List)Node, instead got: class=<{}>",
-                                    catCtx.getQueryName(), left.getClass().getName()
-                            );
+                    throw new IllegalStateException(
+                            "visit of leftTree did not return a StepNode or StepListNode, instead got: class= "
+                                    + left.getClass().getName()
+                    );
                 }
                 // Add right branch
                 if (rightTree != null) {

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -113,6 +113,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
         }
         else {
             LOGGER.info("queryId <{}> -> Left tree NULL", catCtx.getQueryName());
+            throw new IllegalArgumentException("Left tree is Null" );
         }
 
         if (rightTree != null) {

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -112,8 +112,11 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
             LOGGER.info("queryId <{}> -> Left tree: text=<{}>", catCtx.getQueryName(), leftTree.getText());
         }
         else {
-            LOGGER.info("queryId <{}> -> Left tree NULL", catCtx.getQueryName());
-            throw new IllegalArgumentException("Left tree is Null" );
+            LOGGER.error("queryId <{}> -> Left tree NULL", catCtx.getQueryName());
+            throw new IllegalArgumentException(
+                    "Transformation command was not given or the given command is not yet implemented, TransformStatement: <"
+                            + ctx.getText() + ">"
+            );
         }
 
         if (rightTree != null) {

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -104,21 +104,10 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
 
         // Proceed leaves
         Node left;
-        ParseTree leftTree = ctx.getChild(0);
-        ParseTree rightTree = ctx.getChild(2);
+        final ParseTree leftTree = ctx.getChild(0);
+        final ParseTree rightTree = ctx.getChild(2);
 
         // Logging
-        if (leftTree != null) {
-            LOGGER.info("queryId <{}> -> Left tree: text=<{}>", catCtx.getQueryName(), leftTree.getText());
-        }
-        else {
-            LOGGER.error("queryId <{}> -> Left tree NULL", catCtx.getQueryName());
-            throw new IllegalArgumentException(
-                    "Transformation command was not given or the given command is not yet implemented, TransformStatement: <"
-                            + ctx.getText() + ">"
-            );
-        }
-
         if (rightTree != null) {
             LOGGER.info("queryId <{}> -> Right tree: text=<{}>", catCtx.getQueryName(), rightTree.getText());
         }
@@ -126,47 +115,59 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
             LOGGER.info("queryId <{}> -> Right tree NULL", catCtx.getQueryName());
         }
 
-        // Visit command transformations
-        left = visit(leftTree);
-
-        if (left != null) {
-            if (left instanceof StepNode) {
-                LOGGER.debug("Add step to list");
-                this.catVisitor.getStepList().add(((StepNode) left).get());
-            }
-            else if (left instanceof StepListNode) {
-                LOGGER.debug("Add multiple steps to list");
-                ((StepListNode) left).asList().forEach(step -> this.catVisitor.getStepList().add(step));
-            }
-            else {
-                LOGGER
-                        .error(
-                                "queryId <{}> visit of leftTree did not return Step(List)Node, instead got: class=<{}>",
-                                catCtx.getQueryName(), left.getClass().getName()
-                        );
-            }
-            // Add right branch
-            if (rightTree != null) {
-                Node right = visit(rightTree);
-                if (right != null) {
-                    LOGGER.debug("Right side was not null: <{}>", right);
-                    left = right;
+        if (leftTree != null) {
+            LOGGER.info("-> Left tree: text=<{}>", leftTree.getText());
+            // Visit command transformations
+            left = visit(leftTree);
+            if (left != null) {
+                if (left instanceof StepNode) {
+                    LOGGER.debug("Add step to list");
+                    this.catVisitor.getStepList().add(((StepNode) left).get());
+                }
+                else if (left instanceof StepListNode) {
+                    LOGGER.debug("Add multiple steps to list");
+                    ((StepListNode) left).asList().forEach(step -> this.catVisitor.getStepList().add(step));
                 }
                 else {
-                    LOGGER.debug("transformStatement <EOF>");
+                    LOGGER
+                            .error(
+                                    "queryId <{}> visit of leftTree did not return Step(List)Node, instead got: class=<{}>",
+                                    catCtx.getQueryName(), left.getClass().getName()
+                            );
                 }
-            }
-            else { // EOF, return only left
-                LOGGER.debug("transformStatement <EOF> return only left transformation");
-            }
+                // Add right branch
+                if (rightTree != null) {
+                    final Node right = visit(rightTree);
+                    if (right != null) {
+                        LOGGER.debug("Right side was not null: <{}>", right);
+                        left = right;
+                    }
+                    else {
+                        LOGGER.debug("transformStatement <EOF>");
+                    }
+                }
+                else { // EOF, return only left
+                    LOGGER.debug("transformStatement <EOF> return only left transformation");
+                }
 
-            return left;
+                return left;
+            }
+            else {
+                // If null is returned, the command is not implemented.
+                // All implemented commands return a StepNode or a StepListNode.
+                LOGGER.error("-> Visit of LeftTree returned NULL");
+                throw new IllegalArgumentException(
+                        "The provided transformation command '" + ctx.getText() + "' is not yet implemented."
+                );
+            }
         }
         else {
-            // If null is returned, the command is not implemented.
-            // All implemented commands return a StepNode or a StepListNode.
-            throw new IllegalArgumentException("The provided command '" + ctx.getText() + "' is not yet implemented.");
+            LOGGER.error("-> Left tree is NULL");
+            throw new IllegalArgumentException(
+                    "The provided transformation command '" + ctx.getText() + "' is not yet implemented."
+            );
         }
+
     }
 
     @Override

--- a/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
+++ b/src/main/java/com/teragrep/pth_10/ast/commands/transformstatement/TransformStatement.java
@@ -108,7 +108,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
         final ParseTree rightTree = ctx.getChild(2);
 
         if (leftTree != null) {
-            LOGGER.info("-> Left tree: text=<{}>", leftTree.getText());
+            LOGGER.info("queryId <{}> -> Left tree: text=<{}>", catCtx.getQueryName(), leftTree.getText());
             // Visit command transformations
             left = visit(leftTree);
             if (left != null) {
@@ -148,7 +148,7 @@ public class TransformStatement extends DPLParserBaseVisitor<Node> {
             else {
                 // If null is returned, the command is not implemented.
                 // All implemented commands return a StepNode or a StepListNode.
-                LOGGER.error("-> Visit of LeftTree returned NULL");
+                LOGGER.error("queryId <{}> -> Visit of LeftTree returned NULL", catCtx.getQueryName());
                 throw new IllegalArgumentException(
                         "The provided transformation command '" + ctx.getText() + "' is not yet implemented."
                 );

--- a/src/test/java/com/teragrep/pth_10/UnimplementedCommandTest.java
+++ b/src/test/java/com/teragrep/pth_10/UnimplementedCommandTest.java
@@ -106,7 +106,8 @@ public class UnimplementedCommandTest {
                 });
         Assertions
                 .assertEquals(
-                        "The provided command 'dumpbasefilename=\"test\"' is not yet implemented.", iae.getMessage()
+                        "The provided transformation command 'dumpbasefilename=\"test\"' is not yet implemented.",
+                        iae.getMessage()
                 );
     }
 
@@ -122,7 +123,8 @@ public class UnimplementedCommandTest {
                 });
         Assertions
                 .assertEquals(
-                        "The provided command 'dumpbasefilename=\"test\"' is not yet implemented.", iae.getMessage()
+                        "The provided transformation command 'dumpbasefilename=\"test\"' is not yet implemented.",
+                        iae.getMessage()
                 );
     }
 }


### PR DESCRIPTION
## Description
Passing null pointer leftTree to visit, which dereferences it.

<!-- Please include a summary of changes made in your pull request. -->
Added exception if leftTree is null to avoid passing null to visit function

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
