### PR TITLE
add without filter pattern option

### DIFF
--- a/src/main/java/com/teragrep/pth10/datasources/DPLDatasource.java
+++ b/src/main/java/com/teragrep/pth10/datasources/DPLDatasource.java
@@ -181,6 +181,12 @@ public class DPLDatasource {
             reader = reader.option("bloom.withoutFilter", bloomWithoutFilter);
         }
 
+        if (config.hasPath("dpl.pth_06.bloom.withoutFilterPattern")) {
+            String withoutFilterPattern = config.getString("dpl.pth_06.bloom.withoutFilterPattern");
+            LOGGER.debug("Found config dpl.pth_06.bloom.withoutFilterPattern=<[{}]>", withoutFilterPattern);
+            reader = reader.option("bloom.withoutFilterPattern", withoutFilterPattern);
+        }
+
         if (config.getBoolean("dpl.pth_06.kafka.enabled")) {
             LOGGER.debug("Kafka is enabled");
             String s3identityWithoutDomain = s3identity;


### PR DESCRIPTION
## Description
Add `dpl.pth_06.bloom.withoutFilterPattern` option to `DPLDatasource` class. This value is used to determine the pattern of the filters that are checked when querying for files without bloom filters.

Does not check if the  `dpl.pth_06.bloom.withoutFilters` option is enabled