### PR TITLE
fixes for dpl test cases with incorrect timestamp formats

### DIFF
--- a/src/test/java/com/teragrep/pth10/BloomFilterOperationsTest.java
+++ b/src/test/java/com/teragrep/pth10/BloomFilterOperationsTest.java
@@ -111,7 +111,7 @@ public class BloomFilterOperationsTest {
     public void estimateTest() {
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 | teragrep exec tokenizer | teragrep exec bloom estimate",
+                        "index=index_A earliest=2020-01-01T00:00:00Z latest=2023-01-01T00:00:00Z | teragrep exec tokenizer | teragrep exec bloom estimate",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(
@@ -154,7 +154,7 @@ public class BloomFilterOperationsTest {
         streamingTestUtil
                 .performDPLTest(
                         // index_Empty _raw = "" so tokenizer step will produce an empty array
-                        "index=index_Empty earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 | teragrep exec tokenizer | teragrep exec bloom estimate",
+                        "index=index_Empty earliest=2020-01-01T00:00:00Z latest=2023-01-01T00:00:00Z | teragrep exec tokenizer | teragrep exec bloom estimate",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(
@@ -201,7 +201,7 @@ public class BloomFilterOperationsTest {
         properties.put("dpl.pth_06.bloom.db.fields", "[ {expected: 100, fpp: 0.01}]");
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 "
+                        "index=index_A earliest=2020-01-01T00:00:00Z latest=2023-01-01T00:00:00Z "
                                 + "| teragrep exec tokenizer format bytes "
                                 + "| teragrep exec hdfs save overwrite=true /tmp/pth_10_hdfs/aggregatorTokenBytes/"
                                 + id,
@@ -266,7 +266,7 @@ public class BloomFilterOperationsTest {
         final String regex = "\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}";
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 "
+                        "index=index_A earliest=2020-01-01T00:00:00Z latest=2023-01-01T00:00:00Z "
                                 + "| teragrep exec regexextract regex " + regex
                                 + "| teragrep exec hdfs save overwrite=true /tmp/pth_10_hdfs/aggregatorTokenBytes/"
                                 + id,

--- a/src/test/java/com/teragrep/pth10/BloomFilterOperationsTest.java
+++ b/src/test/java/com/teragrep/pth10/BloomFilterOperationsTest.java
@@ -111,7 +111,7 @@ public class BloomFilterOperationsTest {
     public void estimateTest() {
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00z latest=2023-01-01T00:00:00z | teragrep exec tokenizer | teragrep exec bloom estimate",
+                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 | teragrep exec tokenizer | teragrep exec bloom estimate",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(
@@ -154,7 +154,7 @@ public class BloomFilterOperationsTest {
         streamingTestUtil
                 .performDPLTest(
                         // index_Empty _raw = "" so tokenizer step will produce an empty array
-                        "index=index_Empty earliest=2020-01-01T00:00:00z latest=2023-01-01T00:00:00z | teragrep exec tokenizer | teragrep exec bloom estimate",
+                        "index=index_Empty earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 | teragrep exec tokenizer | teragrep exec bloom estimate",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(
@@ -201,7 +201,7 @@ public class BloomFilterOperationsTest {
         properties.put("dpl.pth_06.bloom.db.fields", "[ {expected: 100, fpp: 0.01}]");
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00z latest=2023-01-01T00:00:00z "
+                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 "
                                 + "| teragrep exec tokenizer format bytes "
                                 + "| teragrep exec hdfs save overwrite=true /tmp/pth_10_hdfs/aggregatorTokenBytes/"
                                 + id,
@@ -266,7 +266,7 @@ public class BloomFilterOperationsTest {
         final String regex = "\\w{8}-\\w{4}-\\w{4}-\\w{4}-\\w{12}";
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00z latest=2023-01-01T00:00:00z "
+                        "index=index_A earliest=2020-01-01T00:00:00 latest=2023-01-01T00:00:00 "
                                 + "| teragrep exec regexextract regex " + regex
                                 + "| teragrep exec hdfs save overwrite=true /tmp/pth_10_hdfs/aggregatorTokenBytes/"
                                 + id,

--- a/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
+++ b/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
@@ -112,7 +112,6 @@ public class CatalystVisitorTest {
         final String expected = "(((NOT RLIKE(index, (?i)^strawberry$)) AND (RLIKE(sourcetype, (?i)^example:strawberry:strawberry) AND RLIKE(host, (?i)^loadbalancer.example.com))) OR (RLIKE(index, (?i)^.*$) AND (((RLIKE(host, (?i)^firewall.example.com) AND (_time >= from_unixtime(1611619200, yyyy-MM-dd HH:mm:ss))) AND (_time < from_unixtime(1619395200, yyyy-MM-dd HH:mm:ss))) AND RLIKE(_raw, (?i)^.*\\QDenied\\E.*))))";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             DPLParserCatalystContext ctx = this.streamingTestUtil.getCtx();
-            System.out.println(ctx.getSparkQuery());
             Assertions.assertEquals(expected, ctx.getSparkQuery());
         });
     }

--- a/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
+++ b/src/test/java/com/teragrep/pth10/CatalystVisitorTest.java
@@ -108,10 +108,11 @@ public class CatalystVisitorTest {
             matches = "true"
     )
     void searchQueryWithOrTest() {
-        final String query = "(index!=strawberry sourcetype=example:strawberry:strawberry host=loadbalancer.example.com) OR (index=* host=firewall.example.com earliest=2021-01-26T00:00:00z latest=2021-04-26T00:00:00z \"Denied\")";
-        final String expected = "(((NOT RLIKE(index, (?i)^strawberry$)) AND (RLIKE(sourcetype, (?i)^example:strawberry:strawberry) AND RLIKE(host, (?i)^loadbalancer.example.com))) OR (RLIKE(index, (?i)^.*$) AND (((RLIKE(host, (?i)^firewall.example.com) AND (_time >= from_unixtime(1611612000, yyyy-MM-dd HH:mm:ss))) AND (_time < from_unixtime(1619384400, yyyy-MM-dd HH:mm:ss))) AND RLIKE(_raw, (?i)^.*\\QDenied\\E.*))))";
+        final String query = "(index!=strawberry sourcetype=example:strawberry:strawberry host=loadbalancer.example.com) OR (index=* host=firewall.example.com earliest=2021-01-26T00:00:00Z latest=2021-04-26T00:00:00Z \"Denied\")";
+        final String expected = "(((NOT RLIKE(index, (?i)^strawberry$)) AND (RLIKE(sourcetype, (?i)^example:strawberry:strawberry) AND RLIKE(host, (?i)^loadbalancer.example.com))) OR (RLIKE(index, (?i)^.*$) AND (((RLIKE(host, (?i)^firewall.example.com) AND (_time >= from_unixtime(1611619200, yyyy-MM-dd HH:mm:ss))) AND (_time < from_unixtime(1619395200, yyyy-MM-dd HH:mm:ss))) AND RLIKE(_raw, (?i)^.*\\QDenied\\E.*))))";
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             DPLParserCatalystContext ctx = this.streamingTestUtil.getCtx();
+            System.out.println(ctx.getSparkQuery());
             Assertions.assertEquals(expected, ctx.getSparkQuery());
         });
     }

--- a/src/test/java/com/teragrep/pth10/TimechartStreamingTest.java
+++ b/src/test/java/com/teragrep/pth10/TimechartStreamingTest.java
@@ -110,7 +110,7 @@ public class TimechartStreamingTest {
     public void testTimechartBinSizeForMonthSpan() {
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-01-01T00:00:00z latest=2021-01-01T00:00:00z | timechart span=1mon count(_raw) as craw by sourcetype",
+                        "index=index_A earliest=2020-01-01T00:00:00Z latest=2021-01-01T00:00:00Z | timechart span=1mon count(_raw) as craw by sourcetype",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(
@@ -149,7 +149,7 @@ public class TimechartStreamingTest {
     public void testTimechartBinSizeForMinuteSpan() {
         streamingTestUtil
                 .performDPLTest(
-                        "index=index_A earliest=2020-12-12T00:00:00z latest=2020-12-12T00:30:00z | timechart span=1min count(_raw) as craw by sourcetype",
+                        "index=index_A earliest=2020-12-12T00:00:00Z latest=2020-12-12T00:30:00Z | timechart span=1min count(_raw) as craw by sourcetype",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField(


### PR DESCRIPTION
## Description

DPL timestamps had unsupported format  for timezone with `z`, e.g. `earliest=2020-01-01T00:00:00z `.

Changes `z` to correct `Z`.
