### PR TITLE
replace custom UDF with spark from_unixtime for ctime transformation

### DIFF
--- a/src/main/java/com/teragrep/pth10/steps/convert/ConvertStep.java
+++ b/src/main/java/com/teragrep/pth10/steps/convert/ConvertStep.java
@@ -231,12 +231,9 @@ public final class ConvertStep extends AbstractConvertStep {
      * @return Input dataset with added result column
      */
     private Dataset<Row> ctime(Dataset<Row> dataset, String field, String renameField) {
-        UserDefinedFunction ctimeUDF = functions.udf(new Ctime(), DataTypes.StringType);
-        sparkSession.udf().register("UDF_Ctime", ctimeUDF);
-
-        Column udfResult = functions
-                .callUDF("UDF_Ctime", functions.col(field).cast(DataTypes.StringType), functions.lit(timeformat));
-        return dataset.withColumn(renameField == null ? field : renameField, udfResult);
+        final String iso8601Format = "yyyy-MM-dd'T'HH:mm:ssX";
+        final Column result = functions.from_unixtime(functions.col(field), iso8601Format);
+        return dataset.withColumn(renameField == null ? field : renameField, result);
     }
 
     /**

--- a/src/test/java/com/teragrep/pth10/ConvertTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/ConvertTransformationTest.java
@@ -108,7 +108,8 @@ public class ConvertTransformationTest {
                     new StructField("new", DataTypes.StringType, true, new MetadataBuilder().build())
             });
             Assertions.assertEquals(expectedSchema, ds.schema());
-
+            // match yyyy-MM-dd'T'HH:mm:ssZ ISO 8601 with zone
+            Pattern iso8601pattern = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$");
             List<String> listOfResults = ds
                     .select("new")
                     .collectAsList()
@@ -116,10 +117,8 @@ public class ConvertTransformationTest {
                     .map(r -> r.getAs(0).toString())
                     .collect(Collectors.toList());
             for (String s : listOfResults) {
-                // match 00/00/0000 00:00:00
-                Matcher m = Pattern.compile("\\d{2}/\\d{2}/\\d{4} \\d{2}:\\d{2}:\\d{2}").matcher(s);
-
-                Assertions.assertTrue(m.find());
+                Matcher matcher = iso8601pattern.matcher(s);
+                Assertions.assertTrue(matcher.find());
             }
         });
     }
@@ -152,9 +151,10 @@ public class ConvertTransformationTest {
                     .collect(Collectors.toList());
             List<String> expectedResults = Arrays
                     .asList(
-                            "01/01/1970 00:00:11", "01/01/1970 00:00:11", "01/01/1970 00:00:10", "01/01/1970 00:00:09",
-                            "01/01/1970 00:00:08", "01/01/1970 00:00:07", "01/01/1970 00:00:06", "01/01/1970 00:00:05",
-                            "01/01/1970 00:00:04", "01/01/1970 00:00:03", "01/01/1970 00:00:02", "01/01/1970 00:00:01"
+                            "1970-01-01T00:00:11Z", "1970-01-01T00:00:11Z", "1970-01-01T00:00:10Z",
+                            "1970-01-01T00:00:09Z", "1970-01-01T00:00:08Z", "1970-01-01T00:00:07Z",
+                            "1970-01-01T00:00:06Z", "1970-01-01T00:00:05Z", "1970-01-01T00:00:04Z",
+                            "1970-01-01T00:00:03Z", "1970-01-01T00:00:02Z", "1970-01-01T00:00:01Z"
                     );
 
             for (int i = 0; i < listOfResults.size(); i++) {

--- a/src/test/java/com/teragrep/pth10/ConvertTransformationTest.java
+++ b/src/test/java/com/teragrep/pth10/ConvertTransformationTest.java
@@ -116,6 +116,7 @@ public class ConvertTransformationTest {
                     .stream()
                     .map(r -> r.getAs(0).toString())
                     .collect(Collectors.toList());
+            Assertions.assertEquals(12, listOfResults.size());
             for (String s : listOfResults) {
                 Matcher matcher = iso8601pattern.matcher(s);
                 Assertions.assertTrue(matcher.find());
@@ -149,6 +150,7 @@ public class ConvertTransformationTest {
                     .stream()
                     .map(r -> r.getAs(0).toString())
                     .collect(Collectors.toList());
+            Assertions.assertEquals(12, listOfResults.size());
             List<String> expectedResults = Arrays
                     .asList(
                             "1970-01-01T00:00:11Z", "1970-01-01T00:00:11Z", "1970-01-01T00:00:10Z",


### PR DESCRIPTION
## Description
Use spark's `functions.from_unixtime` to parse epochs into a timestamp string replacing the old custom UDF.
Resulting timestamp strings are now returned in ISO 8601 standard and include zone information. 

Example:
epoch `1` results into `1970-01-01T00:00:01Z`.

I chose this format but we can use that is supported by the `DateTimeFormatter`.