### PR TITLE
better gson exception messages when parsing filter fields from gson

### DIFF
--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
@@ -53,12 +53,12 @@ public final class BloomFilterConfiguration implements Comparable<BloomFilterCon
     private final Long expected;
     private final Double fpp;
 
-    public BloomFilterConfiguration(final long expected, final Double fpp) {
+    public BloomFilterConfiguration(final Long expected, final Double fpp) {
         this.expected = expected;
         this.fpp = fpp;
     }
 
-    public long expectedNumOfItems() {
+    public Long expectedNumOfItems() {
         return expected;
     }
 

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
@@ -89,7 +89,8 @@ public final class BloomFilterConfiguration implements Comparable<BloomFilterCon
             return 0;
         }
         if (expected.equals(other.expected)) {
-            if (fpp > other.fpp) {
+            // larger fpp results in a smaller filter bit size
+            if (fpp < other.fpp) {
                 return 1;
             }
             else {

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import java.util.Objects;
+
+public final class BloomFilterConfiguration implements Comparable<BloomFilterConfiguration> {
+
+    // member field names must be exactly these so Gson can parse them from JSON
+    private final Long expected;
+    private final Double fpp;
+
+    public BloomFilterConfiguration(final long expected, final Double fpp) {
+        this.expected = expected;
+        this.fpp = fpp;
+    }
+
+    public long expectedNumOfItems() {
+        return expected;
+    }
+
+    public Double falsePositiveProbability() {
+        return fpp;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object)
+            return true;
+        if (object == null)
+            return false;
+        if (object.getClass() != this.getClass())
+            return false;
+        final BloomFilterConfiguration cast = (BloomFilterConfiguration) object;
+        return expected.equals(cast.expected) && fpp.equals(cast.fpp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expected, fpp);
+    }
+
+    @Override
+    public int compareTo(final BloomFilterConfiguration other) {
+        if (equals(other)) {
+            return 0;
+        }
+        if (expected.equals(other.expected)) {
+            if (fpp > other.fpp) {
+                return 1;
+            }
+            else {
+                return -1;
+            }
+        }
+        else if (expected > other.expected) {
+            return 1;
+        }
+        else {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
+++ b/src/main/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypes.java
@@ -87,7 +87,7 @@ public final class FilterTypes implements Serializable {
             }.getType());
         }
         catch (final JsonIOException | JsonSyntaxException e) {
-            throw new RuntimeException(
+            throw new IllegalArgumentException(
                     "Error parsing 'dpl.pth_06.bloom.db.fields' option to JSON. ensure that filter size options are formated as an JSON array and that there are no duplicate values. "
                             + "example '[{expected: 1000, fpp: 0.01},{expected: 2000, fpp: 0.01}]'. message: "
                             + e.getMessage()
@@ -102,7 +102,7 @@ public final class FilterTypes implements Serializable {
 
         final boolean hasDuplicates = new HashSet<>(filterConfigurationList).size() != filterConfigurationList.size();
         if (hasDuplicates) {
-            throw new RuntimeException("Found duplicate values in 'dpl.pth_06.bloom.db.fields'");
+            throw new IllegalArgumentException("Found duplicate values in 'dpl.pth_06.bloom.db.fields'");
         }
         return sizesMapFromJson;
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
+ * Copyright (C) 2019-2024 Suomen Kanuuna Oy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ *
+ * Additional permission under GNU Affero General Public License version 3
+ * section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with other code, such other code is not for that reason alone subject to any
+ * of the requirements of the GNU Affero GPL version 3 as long as this Program
+ * is the same Program as licensed from Suomen Kanuuna Oy without any additional
+ * modifications.
+ *
+ * Supplemented terms under GNU Affero General Public License version 3
+ * section 7
+ *
+ * Origin of the software must be attributed to Suomen Kanuuna Oy. Any modified
+ * versions must be marked as "Modified version of" The Program.
+ *
+ * Names of the licensors and authors may not be used for publicity purposes.
+ *
+ * No rights are granted for use of trade names, trademarks, or service marks
+ * which are in The Program if any.
+ *
+ * Licensee must indemnify licensors and authors for any liability that these
+ * contractual assumptions impose on licensors and authors.
+ *
+ * To the extent this program is licensed as part of the Commercial versions of
+ * Teragrep, the applicable Commercial License may apply to this file if you as
+ * a licensee so wish it.
+ */
+package com.teragrep.pth10.steps.teragrep.bloomfilter;
+
+import com.google.gson.Gson;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.sparkproject.guava.reflect.TypeToken;
+
+public final class BloomFilterConfigurationTest {
+
+    @Test
+    public void testOptions() {
+        final BloomFilterConfiguration configuration = new BloomFilterConfiguration(1000L, 0.01);
+        Assertions.assertEquals(1000L, configuration.expectedNumOfItems());
+        Assertions.assertEquals(0.01, configuration.falsePositiveProbability());
+    }
+
+    @Test
+    public void testGsonParseable() {
+        final String json = "{expected:1000,fpp:0.01}";
+        final Gson gson = new Gson();
+        final BloomFilterConfiguration parsedObject = Assertions
+                .assertDoesNotThrow(() -> gson.fromJson(json, new TypeToken<BloomFilterConfiguration>() {
+                }.getType()));
+        Assertions.assertEquals(1000L, parsedObject.expectedNumOfItems());
+        Assertions.assertEquals(0.01, parsedObject.falsePositiveProbability());
+    }
+
+    @Test
+    public void testContract() {
+        EqualsVerifier.forClass(BloomFilterConfiguration.class).withNonnullFields("expected", "fpp").verify();
+    }
+
+    @Test
+    public void testEquality() {
+        final BloomFilterConfiguration base = new BloomFilterConfiguration(1000L, 0.01);
+        final BloomFilterConfiguration equals = new BloomFilterConfiguration(1000L, 0.01);
+        Assertions.assertEquals(base, equals);
+    }
+
+    @Test
+    public void testNonEquality() {
+        final BloomFilterConfiguration base = new BloomFilterConfiguration(1000L, 0.01);
+        final BloomFilterConfiguration nonEquals = new BloomFilterConfiguration(2000L, 0.01);
+        final BloomFilterConfiguration nonEquals2 = new BloomFilterConfiguration(1000L, 0.02);
+        Assertions.assertNotEquals(base, nonEquals);
+        Assertions.assertNotEquals(base, nonEquals2);
+    }
+
+    @Test
+    public void testComparable() {
+        final BloomFilterConfiguration base = new BloomFilterConfiguration(1000L, 0.02);
+        final BloomFilterConfiguration equals = new BloomFilterConfiguration(1000L, 0.02);
+        final BloomFilterConfiguration smaller = new BloomFilterConfiguration(500, 0.02);
+        final BloomFilterConfiguration larger = new BloomFilterConfiguration(2000L, 0.02);
+        final BloomFilterConfiguration smallerFpp = new BloomFilterConfiguration(1000L, 0.01);
+        final BloomFilterConfiguration largerFpp = new BloomFilterConfiguration(1000L, 0.03);
+        Assertions.assertEquals(0, base.compareTo(equals));
+        Assertions.assertEquals(1, base.compareTo(smaller));
+        Assertions.assertEquals(-1, base.compareTo(larger));
+        Assertions.assertEquals(1, base.compareTo(smallerFpp));
+        Assertions.assertEquals(-1, base.compareTo(largerFpp));
+    }
+}

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
@@ -102,6 +102,8 @@ public final class BloomFilterConfigurationTest {
         final BloomFilterConfiguration largerFpp = new BloomFilterConfiguration(1000L, 0.03);
         final BloomFilterConfiguration bothLarger = new BloomFilterConfiguration(2000L, 0.03);
         final BloomFilterConfiguration bothSmaller = new BloomFilterConfiguration(500L, 0.01);
+        final BloomFilterConfiguration smallerExpectedLargerFpp = new BloomFilterConfiguration(500L, 0.03);
+        final BloomFilterConfiguration largerExpectedSmallerFpp = new BloomFilterConfiguration(2000L, 0.01);
         Assertions.assertEquals(0, base.compareTo(equals));
         Assertions.assertEquals(1, base.compareTo(smaller));
         Assertions.assertEquals(-1, base.compareTo(larger));
@@ -109,5 +111,7 @@ public final class BloomFilterConfigurationTest {
         Assertions.assertEquals(1, base.compareTo(largerFpp));
         Assertions.assertEquals(-1, base.compareTo(bothLarger));
         Assertions.assertEquals(1, base.compareTo(bothSmaller));
+        Assertions.assertEquals(1, base.compareTo(smallerExpectedLargerFpp));
+        Assertions.assertEquals(-1, base.compareTo(largerExpectedSmallerFpp));
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
@@ -100,10 +100,14 @@ public final class BloomFilterConfigurationTest {
         final BloomFilterConfiguration larger = new BloomFilterConfiguration(2000L, 0.02);
         final BloomFilterConfiguration smallerFpp = new BloomFilterConfiguration(1000L, 0.01);
         final BloomFilterConfiguration largerFpp = new BloomFilterConfiguration(1000L, 0.03);
+        final BloomFilterConfiguration bothLarger = new BloomFilterConfiguration(2000L, 0.03);
+        final BloomFilterConfiguration bothSmaller = new BloomFilterConfiguration(500L, 0.01);
         Assertions.assertEquals(0, base.compareTo(equals));
         Assertions.assertEquals(1, base.compareTo(smaller));
         Assertions.assertEquals(-1, base.compareTo(larger));
-        Assertions.assertEquals(1, base.compareTo(smallerFpp));
-        Assertions.assertEquals(-1, base.compareTo(largerFpp));
+        Assertions.assertEquals(-1, base.compareTo(smallerFpp));
+        Assertions.assertEquals(1, base.compareTo(largerFpp));
+        Assertions.assertEquals(-1, base.compareTo(bothLarger));
+        Assertions.assertEquals(1, base.compareTo(bothSmaller));
     }
 }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/BloomFilterConfigurationTest.java
@@ -96,7 +96,7 @@ public final class BloomFilterConfigurationTest {
     public void testComparable() {
         final BloomFilterConfiguration base = new BloomFilterConfiguration(1000L, 0.02);
         final BloomFilterConfiguration equals = new BloomFilterConfiguration(1000L, 0.02);
-        final BloomFilterConfiguration smaller = new BloomFilterConfiguration(500, 0.02);
+        final BloomFilterConfiguration smaller = new BloomFilterConfiguration(500L, 0.02);
         final BloomFilterConfiguration larger = new BloomFilterConfiguration(2000L, 0.02);
         final BloomFilterConfiguration smallerFpp = new BloomFilterConfiguration(1000L, 0.01);
         final BloomFilterConfiguration largerFpp = new BloomFilterConfiguration(1000L, 0.03);

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -153,7 +153,7 @@ public final class FilterTypesTest {
                 );
         final Config config = ConfigFactory.parseProperties(properties);
         final FilterTypes filterTypes = new FilterTypes(config);
-        final RuntimeException exception = assertThrows(RuntimeException.class, filterTypes::sortedMap);
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, filterTypes::sortedMap);
         final String expectedMessage = "Error parsing 'dpl.pth_06.bloom.db.fields' option to JSON. ensure that filter size options are formated as an JSON array and that there are no duplicate values. example '[{expected: 1000, fpp: 0.01},{expected: 2000, fpp: 0.01}]'. message:";
         Assertions.assertTrue(exception.getMessage().startsWith(expectedMessage));
     }
@@ -168,7 +168,7 @@ public final class FilterTypesTest {
                 );
         final Config config = ConfigFactory.parseProperties(properties);
         final FilterTypes filterTypes = new FilterTypes(config);
-        final RuntimeException exception = assertThrows(RuntimeException.class, filterTypes::sortedMap);
+        final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, filterTypes::sortedMap);
         final String expectedMessage = "Found duplicate values in 'dpl.pth_06.bloom.db.fields'";
         Assertions.assertEquals(expectedMessage, exception.getMessage());
     }

--- a/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
+++ b/src/test/java/com/teragrep/pth10/steps/teragrep/bloomfilter/FilterTypesTest.java
@@ -65,7 +65,7 @@ import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class FilterTypesTest {
+public final class FilterTypesTest {
 
     private final String username = "sa";
     private final String password = "";
@@ -77,9 +77,6 @@ class FilterTypesTest {
     public void setup() {
         Assertions.assertDoesNotThrow(() -> {
             conn.prepareStatement("DROP ALL OBJECTS").execute(); // h2 clear database
-        });
-        Assertions.assertDoesNotThrow(() -> {
-            Class.forName("org.h2.Driver");
         });
         String createFilterType = "CREATE TABLE `filtertype` ("
                 + "`id`               bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,"
@@ -144,6 +141,36 @@ class FilterTypesTest {
             Assertions.assertEquals(Arrays.asList(0.01, 0.02, 0.03), fppList);
             result.close();
         });
+    }
+
+    @Test
+    public void testMalformattedFieldsOption() {
+        final Properties properties = new Properties();
+        properties
+                .put(
+                        "dpl.pth_06.bloom.db.fields",
+                        "{expected: 1000, fpp: 0.01},{expected: 2000, fpp: 0.01},{expected: 3000, fpp: 0.01}"
+                );
+        final Config config = ConfigFactory.parseProperties(properties);
+        final FilterTypes filterTypes = new FilterTypes(config);
+        final RuntimeException exception = assertThrows(RuntimeException.class, filterTypes::sortedMap);
+        final String expectedMessage = "Error parsing 'dpl.pth_06.bloom.db.fields' option to JSON. ensure that filter size options are formated as an JSON array and that there are no duplicate values. example '[{expected: 1000, fpp: 0.01},{expected: 2000, fpp: 0.01}]'. message:";
+        Assertions.assertTrue(exception.getMessage().startsWith(expectedMessage));
+    }
+
+    @Test
+    public void testDuplicateValues() {
+        final Properties properties = new Properties();
+        properties
+                .put(
+                        "dpl.pth_06.bloom.db.fields",
+                        "[{expected: 1000, fpp: 0.01},{expected: 1000, fpp: 0.01},{expected: 3000, fpp: 0.01}]"
+                );
+        final Config config = ConfigFactory.parseProperties(properties);
+        final FilterTypes filterTypes = new FilterTypes(config);
+        final RuntimeException exception = assertThrows(RuntimeException.class, filterTypes::sortedMap);
+        final String expectedMessage = "Found duplicate values in 'dpl.pth_06.bloom.db.fields'";
+        Assertions.assertEquals(expectedMessage, exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Description
Gives human readable exception if Gson fails to parse bloom filter fields option.

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
