### PR TITLE
Deploy rpm to repo

### DIFF
--- a/.github/workflows/upload_release_github_attachment.yaml
+++ b/.github/workflows/upload_release_github_attachment.yaml
@@ -46,6 +46,6 @@ jobs:
         with:
           from_repository: "${{ github.repository }}"
           from_version: "${{ github.event.release.tag_name }}"
-          to_repository: StrongestNumber9/pkg_01
-          deploy_key: ${{ secrets.DEPLOY_KEY }}
+          to_repository: teragrep/pkg_01
+          deploy_key: ${{ secrets.PKG_01_DEPLOY_KEY }}
           files: rpm/target/rpm/com.teragrep-pth_10/RPMS/noarch/com.teragrep-pth_10-*.noarch.rpm


### PR DESCRIPTION
Requires PKG_01_DEPLOY_KEY secret to be made in teragrep organization level and deploy keys to be configured in pkg_01 repository.