### PR TITLE
Identify Group by columns 

### DIFF
--- a/src/main/java/com/teragrep/pth_10/ast/FilteredColumns.java
+++ b/src/main/java/com/teragrep/pth_10/ast/FilteredColumns.java
@@ -1,6 +1,6 @@
 /*
  * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
- * Copyright (C) 2019-2025 Suomen Kanuuna Oy
+ * Copyright (C) 2019-2026 Suomen Kanuuna Oy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/main/java/com/teragrep/pth_10/ast/StepList.java
+++ b/src/main/java/com/teragrep/pth_10/ast/StepList.java
@@ -380,7 +380,7 @@ public class StepList implements VoidFunction2<Dataset<Row>, Long> {
             final long step = catVisitor.getCatalystContext().getTimeChartSpanSeconds();
 
             // copy metadata to spans as the original column is replaced by spans
-            Metadata timeMetadata = batchDF.schema().apply("_time").metadata();
+            final Metadata timeMetadata = batchDF.schema().apply("_time").metadata();
             final Dataset<Row> rangeDs = catVisitor
                     .getCatalystContext()
                     .getSparkSession()

--- a/src/main/java/com/teragrep/pth_10/ast/StepList.java
+++ b/src/main/java/com/teragrep/pth_10/ast/StepList.java
@@ -379,7 +379,7 @@ public class StepList implements VoidFunction2<Dataset<Row>, Long> {
             final long max = catVisitor.getCatalystContext().getDplMaximumLatest();
             final long step = catVisitor.getCatalystContext().getTimeChartSpanSeconds();
 
-            // copy metadata to spans as the original column gets dropped
+            // copy metadata to spans as the original column is replaced by spans
             Metadata timeMetadata = batchDF.schema().apply("_time").metadata();
             final Dataset<Row> rangeDs = catVisitor
                     .getCatalystContext()
@@ -394,6 +394,7 @@ public class StepList implements VoidFunction2<Dataset<Row>, Long> {
                     .withColumnRenamed("_range", "_time")
                     .orderBy("_time");
             // fill null data with "0" for all types, except for the "_time" column
+            // filling clears metadata, so we copy it to each filled field.
             for (final StructField field : batchDF.schema().fields()) {
                 final String name = field.name();
                 final DataType dataType = field.dataType();

--- a/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
@@ -80,7 +80,7 @@ public final class ChartStep extends AbstractStep {
                 .asScalaBuffer(listOfAggrExpressions.subList(1, listOfAggrExpressions.size()));
         final Seq<Column> seqOfGroupBy = JavaConversions.asScalaBuffer(groupByList);
         Dataset<Row> resultDataset = dataset.groupBy(seqOfGroupBy).agg(mainExpr, seqOfExpr);
-        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+        final Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
         for (Column groupByColumn : groupByList) {
             resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
         }

--- a/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
@@ -49,6 +49,8 @@ import com.teragrep.functions.dpf_02.AbstractStep;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -77,8 +79,12 @@ public final class ChartStep extends AbstractStep {
         final Seq<Column> seqOfExpr = JavaConversions
                 .asScalaBuffer(listOfAggrExpressions.subList(1, listOfAggrExpressions.size()));
         final Seq<Column> seqOfGroupBy = JavaConversions.asScalaBuffer(groupByList);
-
-        return dataset.groupBy(seqOfGroupBy).agg(mainExpr, seqOfExpr);
+        Dataset resultDataset = dataset.groupBy(seqOfGroupBy).agg(mainExpr, seqOfExpr);
+        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+        for (Column groupByColumn : groupByList) {
+            resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
+        }
+        return resultDataset;
     }
 
     public List<Column> aggrExpressionsList() {

--- a/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/chart/ChartStep.java
@@ -79,7 +79,7 @@ public final class ChartStep extends AbstractStep {
         final Seq<Column> seqOfExpr = JavaConversions
                 .asScalaBuffer(listOfAggrExpressions.subList(1, listOfAggrExpressions.size()));
         final Seq<Column> seqOfGroupBy = JavaConversions.asScalaBuffer(groupByList);
-        Dataset resultDataset = dataset.groupBy(seqOfGroupBy).agg(mainExpr, seqOfExpr);
+        Dataset<Row> resultDataset = dataset.groupBy(seqOfGroupBy).agg(mainExpr, seqOfExpr);
         Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
         for (Column groupByColumn : groupByList) {
             resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);

--- a/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
@@ -50,6 +50,8 @@ import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.StreamingQueryException;
 import org.apache.spark.sql.streaming.Trigger;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +82,8 @@ public class EventstatsStep extends AbstractEventstatsStep {
 
         if (byInstruction != null) {
             LOGGER.info("Performing BY-grouped aggregation");
-            aggDs = dataset.groupBy(byInstruction).agg(mainAgg, seqOfAggs);
+            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
+            aggDs = dataset.groupBy(byInstruction).agg(mainAgg, seqOfAggs).withMetadata(byInstruction, metadata);
         }
         else {
             LOGGER.info("Performing direct aggregation");

--- a/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
@@ -82,8 +82,7 @@ public class EventstatsStep extends AbstractEventstatsStep {
 
         if (byInstruction != null) {
             LOGGER.info("Performing BY-grouped aggregation");
-            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-            aggDs = dataset.groupBy(byInstruction).agg(mainAgg, seqOfAggs).withMetadata(byInstruction, metadata);
+            aggDs = dataset.groupBy(byInstruction).agg(mainAgg, seqOfAggs);
         }
         else {
             LOGGER.info("Performing direct aggregation");
@@ -139,7 +138,8 @@ public class EventstatsStep extends AbstractEventstatsStep {
         assert savedDs != null : "Dataset read from file sink was null";
 
         if (byInstruction != null) {
-            resultDs = savedDs.join(aggDs, byInstruction);
+            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+            resultDs = savedDs.join(aggDs, byInstruction).withMetadata(byInstruction, metadata);
         }
         else {
             resultDs = savedDs.crossJoin(aggDs);

--- a/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
@@ -138,7 +138,7 @@ public class EventstatsStep extends AbstractEventstatsStep {
         assert savedDs != null : "Dataset read from file sink was null";
 
         if (byInstruction != null) {
-            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+            final Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
             resultDs = savedDs.join(aggDs, byInstruction).withMetadata(byInstruction, metadata);
         }
         else {

--- a/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/eventstats/EventstatsStep.java
@@ -82,7 +82,7 @@ public class EventstatsStep extends AbstractEventstatsStep {
 
         if (byInstruction != null) {
             LOGGER.info("Performing BY-grouped aggregation");
-            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
+            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
             aggDs = dataset.groupBy(byInstruction).agg(mainAgg, seqOfAggs).withMetadata(byInstruction, metadata);
         }
         else {

--- a/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
@@ -81,7 +81,7 @@ public final class StatsStep extends AbstractStatsStep {
         if (!this.listOfGroupBys.isEmpty()) {
             Seq<Column> seqOfGroupBys = JavaConversions.asScalaBuffer(this.listOfGroupBys);
             Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-            Dataset resultDataset = dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
+            Dataset<Row> resultDataset = dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
             for (Column groupByColumn : listOfGroupBys) {
                 resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
             }

--- a/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
@@ -80,7 +80,7 @@ public final class StatsStep extends AbstractStatsStep {
         // Check for any group by expressions
         if (!this.listOfGroupBys.isEmpty()) {
             Seq<Column> seqOfGroupBys = JavaConversions.asScalaBuffer(this.listOfGroupBys);
-            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+            final Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
             Dataset<Row> resultDataset = dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
             for (Column groupByColumn : listOfGroupBys) {
                 resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);

--- a/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
@@ -80,10 +80,10 @@ public final class StatsStep extends AbstractStatsStep {
         // Check for any group by expressions
         if (!this.listOfGroupBys.isEmpty()) {
             Seq<Column> seqOfGroupBys = JavaConversions.asScalaBuffer(this.listOfGroupBys);
-            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
+            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
             Dataset resultDataset = dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
             for (Column groupByColumn : listOfGroupBys) {
-                resultDataset = resultDataset.withMetadata(groupByColumn.toString(),metadata);
+                resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
             }
             return resultDataset;
         }

--- a/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/stats/StatsStep.java
@@ -48,6 +48,8 @@ package com.teragrep.pth_10.steps.stats;
 import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -78,7 +80,12 @@ public final class StatsStep extends AbstractStatsStep {
         // Check for any group by expressions
         if (!this.listOfGroupBys.isEmpty()) {
             Seq<Column> seqOfGroupBys = JavaConversions.asScalaBuffer(this.listOfGroupBys);
-            return dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
+            Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
+            Dataset resultDataset = dataset.groupBy(seqOfGroupBys).agg(mainExpr, seqOfAggs);
+            for (Column groupByColumn : listOfGroupBys) {
+                resultDataset = resultDataset.withMetadata(groupByColumn.toString(),metadata);
+            }
+            return resultDataset;
         }
         else {
             // No group by, just perform a direct aggregation

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -92,7 +92,7 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .drop("window")
                 .orderBy("_time");
 
-        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+        final Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
         if (Arrays.asList(resultDataset.schema().fieldNames()).contains("_time")) {
             resultDataset = resultDataset.withMetadata("_time", metadata);
         }

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -92,9 +92,9 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .drop("window")
                 .orderBy("_time");
 
-        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
-        for (Column groupByColumn: allGroupBys) {
-            resultDataset = resultDataset.withMetadata(groupByColumn.toString(),metadata);
+        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+        for (Column groupByColumn : allGroupBys) {
+            resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
         }
 
         return resultDataset;

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -46,6 +46,8 @@
 package com.teragrep.pth_10.steps.timechart;
 
 import org.apache.spark.sql.*;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
@@ -81,7 +83,7 @@ public final class TimechartStep extends AbstractTimechartStep {
 
         Seq<Column> seqOfAllGroupBys = JavaConversions.asScalaBuffer(allGroupBys);
 
-        return dataset
+        Dataset resultDataset = dataset
                 .groupBy(seqOfAllGroupBys)
                 .agg(firstAggCol, seqOfAggColsExceptFirst)
                 .drop("_time")
@@ -89,5 +91,12 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .withColumnRenamed("start", "_time")
                 .drop("window")
                 .orderBy("_time");
+
+        Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn",true).build();
+        for (Column groupByColumn: allGroupBys) {
+            resultDataset = resultDataset.withMetadata(groupByColumn.toString(),metadata);
+        }
+
+        return resultDataset;
     }
 }

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -82,8 +82,7 @@ public final class TimechartStep extends AbstractTimechartStep {
         allGroupBys.addAll(this.divByInsts.stream().map(functions::col).collect(Collectors.toList()));
 
         Seq<Column> seqOfAllGroupBys = JavaConversions.asScalaBuffer(allGroupBys);
-
-        Dataset resultDataset = dataset
+        Dataset<Row> resultDataset = dataset
                 .groupBy(seqOfAllGroupBys)
                 .agg(firstAggCol, seqOfAggColsExceptFirst)
                 .drop("_time")
@@ -93,8 +92,13 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .orderBy("_time");
 
         Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-        for (Column groupByColumn : allGroupBys) {
-            resultDataset = resultDataset.withMetadata(groupByColumn.toString(), metadata);
+        if(resultDataset.schema().contains("_time")){
+            resultDataset = resultDataset.withMetadata("_time",metadata);
+        }
+        if(divByInsts != null){
+            for (String groupByColumn : divByInsts) {
+                resultDataset = resultDataset.withMetadata(groupByColumn, metadata);
+            }
         }
 
         return resultDataset;

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -52,6 +52,7 @@ import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -92,7 +93,7 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .orderBy("_time");
 
         Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-        if (resultDataset.schema().contains("_time")) {
+        if (Arrays.asList(resultDataset.schema().fieldNames()).contains("_time")) {
             resultDataset = resultDataset.withMetadata("_time", metadata);
         }
         if (divByInsts != null) {

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -92,10 +92,10 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .orderBy("_time");
 
         Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-        if(resultDataset.schema().contains("_time")){
-            resultDataset = resultDataset.withMetadata("_time",metadata);
+        if (resultDataset.schema().contains("_time")) {
+            resultDataset = resultDataset.withMetadata("_time", metadata);
         }
-        if(divByInsts != null){
+        if (divByInsts != null) {
             for (String groupByColumn : divByInsts) {
                 resultDataset = resultDataset.withMetadata(groupByColumn, metadata);
             }

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -52,7 +52,6 @@ import scala.collection.JavaConversions;
 import scala.collection.Seq;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
+++ b/src/main/java/com/teragrep/pth_10/steps/timechart/TimechartStep.java
@@ -93,9 +93,7 @@ public final class TimechartStep extends AbstractTimechartStep {
                 .orderBy("_time");
 
         final Metadata metadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-        if (Arrays.asList(resultDataset.schema().fieldNames()).contains("_time")) {
-            resultDataset = resultDataset.withMetadata("_time", metadata);
-        }
+        resultDataset = resultDataset.withMetadata("_time", metadata);
         if (divByInsts != null) {
             for (String groupByColumn : divByInsts) {
                 resultDataset = resultDataset.withMetadata(groupByColumn, metadata);

--- a/src/test/java/com/teragrep/pth_10/EventstatsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/EventstatsTransformationTest.java
@@ -45,7 +45,11 @@
  */
 package com.teragrep.pth_10;
 
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;

--- a/src/test/java/com/teragrep/pth_10/EventstatsTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/EventstatsTransformationTest.java
@@ -45,10 +45,7 @@
  */
 package com.teragrep.pth_10;
 
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.MetadataBuilder;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -80,6 +77,10 @@ public class EventstatsTransformationTest {
     });
 
     private StreamingTestUtil streamingTestUtil;
+
+    private final Metadata groupByMetadata = new MetadataBuilder()
+            .putBoolean("dpl_internal_isGroupByColumn", true)
+            .build();
 
     @BeforeAll
     void setEnv() {
@@ -150,7 +151,7 @@ public class EventstatsTransformationTest {
                             new StructField("id", DataTypes.LongType, true, new MetadataBuilder().build()),
                             new StructField("_raw", DataTypes.StringType, true, new MetadataBuilder().build()),
                             new StructField("index", DataTypes.StringType, true, new MetadataBuilder().build()),
-                            new StructField("sourcetype", DataTypes.StringType, true, new MetadataBuilder().build()),
+                            new StructField("sourcetype", DataTypes.StringType, true, groupByMetadata),
                             new StructField("host", DataTypes.StringType, true, new MetadataBuilder().build()),
                             new StructField("source", DataTypes.StringType, true, new MetadataBuilder().build()),
                             new StructField("partition", DataTypes.StringType, true, new MetadataBuilder().build()),

--- a/src/test/java/com/teragrep/pth_10/FilteredColumnsTest.java
+++ b/src/test/java/com/teragrep/pth_10/FilteredColumnsTest.java
@@ -1,6 +1,6 @@
 /*
  * Teragrep Data Processing Language (DPL) translator for Apache Spark (pth_10)
- * Copyright (C) 2019-2025 Suomen Kanuuna Oy
+ * Copyright (C) 2019-2026 Suomen Kanuuna Oy
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
@@ -78,6 +78,7 @@ public class PredictTransformationTest {
     private final Metadata groupByMetadata = new MetadataBuilder()
             .putBoolean("dpl_internal_isGroupByColumn", true)
             .build();
+
     @BeforeAll
     void setEnv() {
         this.streamingTestUtil = new StreamingTestUtil(this.testSchema);
@@ -114,7 +115,8 @@ public class PredictTransformationTest {
                                     new StructField(
                                             "_time",
                                             DataTypes.TimestampType,
-                                            false, groupByMetadata
+                                            false,
+                                            groupByMetadata
 
                                     ),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
@@ -157,12 +159,7 @@ public class PredictTransformationTest {
                         "index=* | timechart span=1h avg(offset) as avgo | predict avgo AS pred future_timespan=10",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
-                                    new StructField(
-                                            "_time",
-                                            DataTypes.TimestampType,
-                                            false,
-                                            groupByMetadata
-                                    ),
+                                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
                                     new StructField("pred", DataTypes.DoubleType, true, new MetadataBuilder().build()),
                                     new StructField(
@@ -203,12 +200,7 @@ public class PredictTransformationTest {
                         "index=* | timechart span=1h avg(offset) as avgo | predict avgo AS pred algorithm=LLT future_timespan=10 ",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
-                                    new StructField(
-                                            "_time",
-                                            DataTypes.TimestampType,
-                                            false,
-                                            groupByMetadata
-                                    ),
+                                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
                                     new StructField("pred", DataTypes.DoubleType, true, new MetadataBuilder().build()),
                                     new StructField(

--- a/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
@@ -46,10 +46,7 @@
 package com.teragrep.pth_10;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.MetadataBuilder;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -78,6 +75,9 @@ public class PredictTransformationTest {
 
     private StreamingTestUtil streamingTestUtil;
 
+    private final Metadata groupByMetadata = new MetadataBuilder()
+            .putBoolean("dpl_internal_isGroupByColumn", true)
+            .build();
     @BeforeAll
     void setEnv() {
         this.streamingTestUtil = new StreamingTestUtil(this.testSchema);
@@ -114,8 +114,8 @@ public class PredictTransformationTest {
                                     new StructField(
                                             "_time",
                                             DataTypes.TimestampType,
-                                            false,
-                                            new MetadataBuilder().build()
+                                            false, groupByMetadata
+
                                     ),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
                                     new StructField("pred", DataTypes.DoubleType, true, new MetadataBuilder().build()),
@@ -161,7 +161,7 @@ public class PredictTransformationTest {
                                             "_time",
                                             DataTypes.TimestampType,
                                             false,
-                                            new MetadataBuilder().build()
+                                            groupByMetadata
                                     ),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
                                     new StructField("pred", DataTypes.DoubleType, true, new MetadataBuilder().build()),
@@ -207,7 +207,7 @@ public class PredictTransformationTest {
                                             "_time",
                                             DataTypes.TimestampType,
                                             false,
-                                            new MetadataBuilder().build()
+                                            groupByMetadata
                                     ),
                                     new StructField("avgo", DataTypes.StringType, true, new MetadataBuilder().build()),
                                     new StructField("pred", DataTypes.DoubleType, true, new MetadataBuilder().build()),

--- a/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/PredictTransformationTest.java
@@ -46,7 +46,11 @@
 package com.teragrep.pth_10;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;

--- a/src/test/java/com/teragrep/pth_10/TimechartStreamingTest.java
+++ b/src/test/java/com/teragrep/pth_10/TimechartStreamingTest.java
@@ -118,12 +118,7 @@ public class TimechartStreamingTest {
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
-                                    new StructField(
-                                            "sourcetype",
-                                            DataTypes.StringType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("sourcetype", DataTypes.StringType, false, groupByMetadata),
                                     new StructField("craw", DataTypes.LongType, false, new MetadataBuilder().build())
                             });
                             Assertions
@@ -152,12 +147,7 @@ public class TimechartStreamingTest {
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
-                                    new StructField(
-                                            "sourcetype",
-                                            DataTypes.StringType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("sourcetype", DataTypes.StringType, false, groupByMetadata),
                                     new StructField("craw", DataTypes.LongType, false, new MetadataBuilder().build())
                             });
                             Assertions
@@ -185,12 +175,7 @@ public class TimechartStreamingTest {
                         "index=index_A | timechart span=1min count(_raw) as craw by sourcetype", testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
                                     new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
-                                    new StructField(
-                                            "sourcetype",
-                                            DataTypes.StringType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("sourcetype", DataTypes.StringType, false, groupByMetadata),
                                     new StructField("craw", DataTypes.LongType, false, new MetadataBuilder().build())
                             });
                             Assertions
@@ -227,7 +212,7 @@ public class TimechartStreamingTest {
         streamingTestUtil.performDPLTest("index=index_A | timechart count by host", testFile, ds -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
-                    new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
+                    new StructField("host", DataTypes.StringType, false, groupByMetadata),
                     new StructField("count", DataTypes.LongType, false, new MetadataBuilder().build())
             });
             Assertions

--- a/src/test/java/com/teragrep/pth_10/TimechartStreamingTest.java
+++ b/src/test/java/com/teragrep/pth_10/TimechartStreamingTest.java
@@ -48,6 +48,7 @@ package com.teragrep.pth_10;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
@@ -82,6 +83,9 @@ public class TimechartStreamingTest {
     });
 
     private StreamingTestUtil streamingTestUtil;
+    private final Metadata groupByMetadata = new MetadataBuilder()
+            .putBoolean("dpl_internal_isGroupByColumn", true)
+            .build();
 
     @BeforeAll
     void setEnv() {
@@ -113,12 +117,7 @@ public class TimechartStreamingTest {
                         "index=index_A earliest=2020-01-01T00:00:00Z latest=2021-01-01T00:00:00Z | timechart span=1mon count(_raw) as craw by sourcetype",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
-                                    new StructField(
-                                            "_time",
-                                            DataTypes.TimestampType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                                     new StructField(
                                             "sourcetype",
                                             DataTypes.StringType,
@@ -152,12 +151,7 @@ public class TimechartStreamingTest {
                         "index=index_A earliest=2020-12-12T00:00:00Z latest=2020-12-12T00:30:00Z | timechart span=1min count(_raw) as craw by sourcetype",
                         testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
-                                    new StructField(
-                                            "_time",
-                                            DataTypes.TimestampType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                                     new StructField(
                                             "sourcetype",
                                             DataTypes.StringType,
@@ -190,12 +184,7 @@ public class TimechartStreamingTest {
                 .performDPLTest(
                         "index=index_A | timechart span=1min count(_raw) as craw by sourcetype", testFile, ds -> {
                             final StructType expectedSchema = new StructType(new StructField[] {
-                                    new StructField(
-                                            "_time",
-                                            DataTypes.TimestampType,
-                                            false,
-                                            new MetadataBuilder().build()
-                                    ),
+                                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                                     new StructField(
                                             "sourcetype",
                                             DataTypes.StringType,
@@ -237,7 +226,7 @@ public class TimechartStreamingTest {
     public void testTimechartSplitBy() {
         streamingTestUtil.performDPLTest("index=index_A | timechart count by host", testFile, ds -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
+                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                     new StructField("host", DataTypes.StringType, false, new MetadataBuilder().build()),
                     new StructField("count", DataTypes.LongType, false, new MetadataBuilder().build())
             });
@@ -268,7 +257,7 @@ public class TimechartStreamingTest {
     public void testTimechartBasicCount() {
         streamingTestUtil.performDPLTest("index=index_A | timechart count", testFile, ds -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("_time", DataTypes.TimestampType, false, new MetadataBuilder().build()),
+                    new StructField("_time", DataTypes.TimestampType, false, groupByMetadata),
                     new StructField("count", DataTypes.LongType, false, new MetadataBuilder().build())
             });
             Assertions

--- a/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
@@ -46,7 +46,11 @@
 package com.teragrep.pth_10;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -66,7 +70,6 @@ public class chartTransformationTest {
     String testFile = "src/test/resources/xmlWalkerTestDataStreaming/xmlWalkerTestDataStreaming*";
     StreamingTestUtil streamingTestUtil;
     Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
-    Metadata emptyMetadata = new MetadataBuilder().build();
 
     @BeforeAll
     void setEnv() {
@@ -90,7 +93,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 
@@ -117,7 +120,7 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("offset", DataTypes.LongType, true, groupByMetadata),
-                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -153,7 +156,7 @@ public class chartTransformationTest {
 
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("offset", DataTypes.LongType, true, groupByMetadata),
-                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -187,7 +190,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count(_raw)", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count(_raw)", DataTypes.LongType, true, new MetadataBuilder().build())
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -222,9 +225,9 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("index", DataTypes.StringType, true, groupByMetadata),
-                    new StructField("count(_raw)", DataTypes.LongType, true, emptyMetadata),
-                    new StructField("min(offset)", DataTypes.StringType, true, emptyMetadata),
-                    new StructField("max(offset)", DataTypes.StringType, true, emptyMetadata)
+                    new StructField("count(_raw)", DataTypes.LongType, true, new MetadataBuilder().build()),
+                    new StructField("min(offset)", DataTypes.StringType, true, new MetadataBuilder().build()),
+                    new StructField("max(offset)", DataTypes.StringType, true, new MetadataBuilder().build())
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -278,7 +281,7 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("_time", DataTypes.StringType, true, groupByMetadata),
-                    new StructField("avg(offset)", DataTypes.DoubleType, true, emptyMetadata),
+                    new StructField("avg(offset)", DataTypes.DoubleType, true, new MetadataBuilder().build()),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -319,7 +322,7 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("sourcetype", DataTypes.StringType, true, groupByMetadata),
-                    new StructField("avg(offset)", DataTypes.DoubleType, true, emptyMetadata),
+                    new StructField("avg(offset)", DataTypes.DoubleType, true, new MetadataBuilder().build()),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -352,7 +355,7 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("offset", DataTypes.LongType, true, groupByMetadata),
-                    new StructField("count(offset)", DataTypes.LongType, true, emptyMetadata),
+                    new StructField("count(offset)", DataTypes.LongType, true, new MetadataBuilder().build()),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -384,7 +387,7 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
                     new StructField("a", DataTypes.StringType, true, groupByMetadata),
-                    new StructField("count(offset)", DataTypes.LongType, true, emptyMetadata),
+                    new StructField("count(offset)", DataTypes.LongType, true, new MetadataBuilder().build()),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -411,7 +414,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 
@@ -433,7 +436,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
+                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 

--- a/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
@@ -46,10 +46,7 @@
 package com.teragrep.pth_10;
 
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.MetadataBuilder;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -68,6 +65,8 @@ public class chartTransformationTest {
 
     String testFile = "src/test/resources/xmlWalkerTestDataStreaming/xmlWalkerTestDataStreaming*";
     StreamingTestUtil streamingTestUtil;
+    Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+    Metadata emptyMetadata = new MetadataBuilder().build();
 
     @BeforeAll
     void setEnv() {
@@ -91,7 +90,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 
@@ -117,8 +116,8 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("offset", DataTypes.LongType, true, new MetadataBuilder().build()),
-                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("offset", DataTypes.LongType, true, groupByMetadata),
+                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -153,8 +152,8 @@ public class chartTransformationTest {
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
 
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("offset", DataTypes.LongType, true, new MetadataBuilder().build()),
-                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("offset", DataTypes.LongType, true, groupByMetadata),
+                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -188,7 +187,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count(_raw)", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("count(_raw)", DataTypes.LongType, true, emptyMetadata)
             });
 
             Assertions.assertEquals(expectedSchema, res.schema()); // At least schema is correct
@@ -222,10 +221,10 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("index", DataTypes.StringType, true, new MetadataBuilder().build()),
-                    new StructField("count(_raw)", DataTypes.LongType, true, new MetadataBuilder().build()),
-                    new StructField("min(offset)", DataTypes.StringType, true, new MetadataBuilder().build()),
-                    new StructField("max(offset)", DataTypes.StringType, true, new MetadataBuilder().build())
+                    new StructField("index", DataTypes.StringType, true, groupByMetadata),
+                    new StructField("count(_raw)", DataTypes.LongType, true, emptyMetadata),
+                    new StructField("min(offset)", DataTypes.StringType, true, emptyMetadata),
+                    new StructField("max(offset)", DataTypes.StringType, true, emptyMetadata)
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -278,8 +277,8 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("_time", DataTypes.StringType, true, new MetadataBuilder().build()),
-                    new StructField("avg(offset)", DataTypes.DoubleType, true, new MetadataBuilder().build()),
+                    new StructField("_time", DataTypes.StringType, true, groupByMetadata),
+                    new StructField("avg(offset)", DataTypes.DoubleType, true, emptyMetadata),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -319,8 +318,8 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("sourcetype", DataTypes.StringType, true, new MetadataBuilder().build()),
-                    new StructField("avg(offset)", DataTypes.DoubleType, true, new MetadataBuilder().build()),
+                    new StructField("sourcetype", DataTypes.StringType, true, groupByMetadata),
+                    new StructField("avg(offset)", DataTypes.DoubleType, true, emptyMetadata),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -352,8 +351,8 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("offset", DataTypes.LongType, true, new MetadataBuilder().build()),
-                    new StructField("count(offset)", DataTypes.LongType, true, new MetadataBuilder().build()),
+                    new StructField("offset", DataTypes.LongType, true, groupByMetadata),
+                    new StructField("count(offset)", DataTypes.LongType, true, emptyMetadata),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -384,8 +383,8 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(q, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("a", DataTypes.StringType, true, new MetadataBuilder().build()),
-                    new StructField("count(offset)", DataTypes.LongType, true, new MetadataBuilder().build()),
+                    new StructField("a", DataTypes.StringType, true, groupByMetadata),
+                    new StructField("count(offset)", DataTypes.LongType, true, emptyMetadata),
             });
 
             Assertions.assertEquals(expectedSchema, res.schema());
@@ -412,7 +411,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 
@@ -434,7 +433,7 @@ public class chartTransformationTest {
 
         this.streamingTestUtil.performDPLTest(query, this.testFile, res -> {
             final StructType expectedSchema = new StructType(new StructField[] {
-                    new StructField("count", DataTypes.LongType, true, new MetadataBuilder().build())
+                    new StructField("count", DataTypes.LongType, true, emptyMetadata)
             });
             Assertions.assertEquals(expectedSchema, res.schema()); // check that the schema is correct
 

--- a/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
+++ b/src/test/java/com/teragrep/pth_10/chartTransformationTest.java
@@ -69,7 +69,7 @@ public class chartTransformationTest {
 
     String testFile = "src/test/resources/xmlWalkerTestDataStreaming/xmlWalkerTestDataStreaming*";
     StreamingTestUtil streamingTestUtil;
-    Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+    final Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
 
     @BeforeAll
     void setEnv() {

--- a/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
+++ b/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
@@ -45,7 +45,11 @@
  */
 package com.teragrep.pth_10;
 
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;

--- a/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
+++ b/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
@@ -45,10 +45,7 @@
  */
 package com.teragrep.pth_10;
 
-import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.MetadataBuilder;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.slf4j.Logger;
@@ -78,6 +75,7 @@ public class statsTransformationStreamingTest {
     });
 
     private StreamingTestUtil streamingTestUtil;
+    private Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
 
     @BeforeAll
     void setEnv() {
@@ -144,6 +142,20 @@ public class statsTransformationStreamingTest {
     public void testSplittingByTime() {
         streamingTestUtil
                 .performDPLTest("index=index_A | stats avg(offset) AS stats_test_result BY _time", testFile, ds -> {
+                    final StructType expectedSchema = new StructType(new StructField[] {
+                            new StructField("_time", DataTypes.TimestampType, true, groupByMetadata),
+                            new StructField(
+                                    "stats_test_result",
+                                    DataTypes.DoubleType,
+                                    true,
+                                    new MetadataBuilder().build()
+                            )
+                    });
+                    Assertions
+                            .assertEquals(
+                                    expectedSchema, ds.schema(),
+                                    "Batch handler dataset contained an unexpected column arrangement !"
+                            );
                     List<String> listOfResult = ds
                             .select("stats_test_result")
                             .collectAsList()
@@ -173,6 +185,20 @@ public class statsTransformationStreamingTest {
         streamingTestUtil
                 .performDPLTest(
                         "index=index_A | stats avg(offset) AS stats_test_result BY sourcetype", testFile, ds -> {
+                            final StructType expectedSchema = new StructType(new StructField[] {
+                                    new StructField("sourcetype", DataTypes.StringType, true, groupByMetadata),
+                                    new StructField(
+                                            "stats_test_result",
+                                            DataTypes.DoubleType,
+                                            true,
+                                            new MetadataBuilder().build()
+                                    )
+                            });
+                            Assertions
+                                    .assertEquals(
+                                            expectedSchema, ds.schema(),
+                                            "Batch handler dataset contained an unexpected column arrangement !"
+                                    );
                             List<String> listOfResult = ds
                                     .select("stats_test_result")
                                     .collectAsList()
@@ -197,6 +223,20 @@ public class statsTransformationStreamingTest {
     public void testSplittingByNumber() {
         streamingTestUtil
                 .performDPLTest("index=index_A | stats avg(offset) AS stats_test_result BY id", testFile, ds -> {
+                    final StructType expectedSchema = new StructType(new StructField[] {
+                            new StructField("id", DataTypes.LongType, true, groupByMetadata),
+                            new StructField(
+                                    "stats_test_result",
+                                    DataTypes.DoubleType,
+                                    true,
+                                    new MetadataBuilder().build()
+                            )
+                    });
+                    Assertions
+                            .assertEquals(
+                                    expectedSchema, ds.schema(),
+                                    "Batch handler dataset contained an unexpected column arrangement !"
+                            );
                     List<String> listOfResult = ds
                             .select("stats_test_result")
                             .collectAsList()
@@ -227,6 +267,21 @@ public class statsTransformationStreamingTest {
         streamingTestUtil
                 .performDPLTest(
                         "index=index_A | stats avg(offset) AS stats_test_result BY sourcetype _time", testFile, ds -> {
+                            final StructType expectedSchema = new StructType(new StructField[] {
+                                    new StructField("sourcetype", DataTypes.StringType, true, groupByMetadata),
+                                    new StructField("_time", DataTypes.TimestampType, true, groupByMetadata),
+                                    new StructField(
+                                            "stats_test_result",
+                                            DataTypes.DoubleType,
+                                            true,
+                                            new MetadataBuilder().build()
+                                    )
+                            });
+                            Assertions
+                                    .assertEquals(
+                                            expectedSchema, ds.schema(),
+                                            "Batch handler dataset contained an unexpected column arrangement !"
+                                    );
                             List<String> listOfResult = ds
                                     .select("stats_test_result")
                                     .collectAsList()
@@ -258,6 +313,20 @@ public class statsTransformationStreamingTest {
                 .performDPLTest(
                         "index=index_A | eval a = offset + 0 | stats avg(offset) AS stats_test_result BY a", testFile,
                         ds -> {
+                            final StructType expectedSchema = new StructType(new StructField[] {
+                                    new StructField("a", DataTypes.StringType, true, groupByMetadata),
+                                    new StructField(
+                                            "stats_test_result",
+                                            DataTypes.DoubleType,
+                                            true,
+                                            new MetadataBuilder().build()
+                                    )
+                            });
+                            Assertions
+                                    .assertEquals(
+                                            expectedSchema, ds.schema(),
+                                            "Batch handler dataset contained an unexpected column arrangement !"
+                                    );
                             List<String> listOfResult = ds
                                     .select("stats_test_result")
                                     .collectAsList()
@@ -282,6 +351,14 @@ public class statsTransformationStreamingTest {
     @Test
     public void statsTransform_Streaming_AggValues_Test() {
         streamingTestUtil.performDPLTest("index=index_A | stats values(offset) AS stats_test_result", testFile, ds -> {
+            final StructType expectedSchema = new StructType(new StructField[] {
+                    new StructField("stats_test_result", DataTypes.StringType, true, new MetadataBuilder().build())
+            });
+            Assertions
+                    .assertEquals(
+                            expectedSchema, ds.schema(),
+                            "Batch handler dataset contained an unexpected column arrangement !"
+                    );
             List<String> listOfResult = ds
                     .select("stats_test_result")
                     .collectAsList()
@@ -303,6 +380,19 @@ public class statsTransformationStreamingTest {
     public void statsTransform_Streaming_AggExactPerc_Test() {
         streamingTestUtil
                 .performDPLTest("index=index_A | stats exactperc50(offset) AS stats_test_result", testFile, ds -> {
+                    final StructType expectedSchema = new StructType(new StructField[] {
+                            new StructField(
+                                    "stats_test_result",
+                                    DataTypes.DoubleType,
+                                    true,
+                                    new MetadataBuilder().build()
+                            )
+                    });
+                    Assertions
+                            .assertEquals(
+                                    expectedSchema, ds.schema(),
+                                    "Batch handler dataset contained an unexpected column arrangement !"
+                            );
                     List<String> listOfResult = ds
                             .select("stats_test_result")
                             .collectAsList()

--- a/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
+++ b/src/test/java/com/teragrep/pth_10/statsTransformationStreamingTest.java
@@ -79,7 +79,9 @@ public class statsTransformationStreamingTest {
     });
 
     private StreamingTestUtil streamingTestUtil;
-    private Metadata groupByMetadata = new MetadataBuilder().putBoolean("dpl_internal_isGroupByColumn", true).build();
+    private final Metadata groupByMetadata = new MetadataBuilder()
+            .putBoolean("dpl_internal_isGroupByColumn", true)
+            .build();
 
     @BeforeAll
     void setEnv() {


### PR DESCRIPTION
resolves #826 
## Description

This PR adds metadata to outputs of ChartStep, TimeChartStep, StatsStep and EventStatsStep which can be used to identify the columns that were used in a groupBy operation when executing the step.
This information can be accessed by obtaining the Dataset's schema, and then checking for the existence of a key called "dpl_internal_isGroupByColumn".

Metadata is used instead of inspecting the LogicalPlan of the resulting dataset, because Dataset.writeStream().forEachBatch() overrides the LogicalPlan for each batch. Metadata, on the other hand, does not get overwritten.

This functionality is required for [zep_01#283](https://github.com/teragrep/zep_01/issues/283), where data formatting needs to get access to column names that were used for grouping data.

<!-- If you can't fill all check boxes in Checklists section, please explain why. -->

## Checklists

<!-- Fill check boxes before submitting the pull request. -->

### Testing

#### General

- [x] I have checked that my test files and functions have meaningful names.
- [x] I have checked that each test tests only a single behavior.
- [x] I have done happy tests.
- [x] I have tested only my own code.
- [x] I have tested at least all public methods. 

#### Assertions

- [x] I have checked that my tests use assertions and not runtime overhead.
- [x] I have checked that my tests end in assertions.
- [x] I have checked that there is no comparison statements in assertions.
- [x] I have checked that assertions are in tests and not in helper functions.
- [x] I have checked that assertions for iterables are outside of for loops and both sides of the iteration blocks.
- [x] I have checked that assertions are not tested inside consumers.

#### Testing Data

- [x] I have tested algorithms and anything else with the possibility of unbound growth.
- [x] I have checked that all testing data is local and fully replaceable or reproducible or both.
- [x] I have checked that all test files are standalone.
- [x] I have checked that all test-specific fake objects and classes are in the test directory.
- [x] I have checked that my tests do not contain anything related to customers, infrastructure or users.
- [x] I have checked that my tests do not contain non-generic information.
- [x] I have checked that my tests do not do external requests and are not privately or publicly routable.

#### Statements

- [x] I have checked that my tests do not use throws for exceptions.
- [x] I have checked that my tests do not use try-catch statements.
- [x] I have checked that my tests do not use if-else statements.

#### Java

- [x] I have checked that my tests for Java uses JUnit library.
- [x] I have checked that my tests for Java uses JUnit utilities for parameters.

#### Other

- [x] I have only tested public behavior and not private implementation details.
- [x] I have checked that my tests are not (partially) commented out.
- [x] I have checked that hand-crafted variables in assertions are used accordingly.
- [x] I have tested [Object Equality](https://docs.oracle.com/javase/6/docs/api/java/lang/Object.html#equals%28java.lang.Object%29).
- [x] I have checked that I do not have any manual tests or I have a valid reason for them and I have explained it in the PR description.

### Code Quality

- [x] I have checked that my code follows metrics set in Procedure: Class Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Method Metrics.
- [x] I have checked that my code follows metrics set in Procedure: Object Quality.
- [x] I have checked that my code does not have any NULL values.
- [x] I have checked my code does not contain FIXME or TODO comments.  
